### PR TITLE
Legacy boot enabling / coverage

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -167,6 +167,7 @@ check_PROGRAMS = $(TESTS)
 
 check_core_SOURCES =		\
 	tests/check-core.c	\
+	tests/blkid-harness.h   \
 	tests/harness.h		\
 	tests/harness.c
 
@@ -225,6 +226,7 @@ check_os_release_LDADD =	\
 
 check_updates_SOURCES =		\
 	tests/check-updates.c	\
+	tests/blkid-harness.h   \
 	tests/harness.h		\
 	tests/harness.c
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -96,6 +96,8 @@ libcbm_la_SOURCES =			\
 	src/bootman/sysconfig.c		\
 	src/bootman/timeout.c		\
 	src/bootman/update.c		\
+	src/lib/blkid_stub.h            \
+	src/lib/blkid_stub.c            \
 	src/lib/cmdline.h               \
 	src/lib/cmdline.c               \
 	src/lib/files.h			\

--- a/Makefile.am
+++ b/Makefile.am
@@ -170,6 +170,7 @@ check_PROGRAMS = $(TESTS)
 check_core_SOURCES =		\
 	tests/check-core.c	\
 	tests/blkid-harness.h   \
+	tests/system-harness.h  \
 	tests/harness.h		\
 	tests/harness.c
 
@@ -229,6 +230,7 @@ check_os_release_LDADD =	\
 check_updates_SOURCES =		\
 	tests/check-updates.c	\
 	tests/blkid-harness.h   \
+	tests/system-harness.h  \
 	tests/harness.h		\
 	tests/harness.c
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -108,6 +108,8 @@ libcbm_la_SOURCES =			\
 	src/lib/log.c			\
 	src/lib/probe.h                 \
 	src/lib/probe.c                 \
+	src/lib/system_stub.h           \
+	src/lib/system_stub.c           \
 	src/lib/writer.h                \
 	src/lib/writer.c                \
 	src/lib/util.h

--- a/src/bootloaders/bootloader.h
+++ b/src/bootloaders/bootloader.h
@@ -13,6 +13,12 @@
 
 #include "bootman.h"
 
+#if UINTPTR_MAX == 0xffffffffffffffff
+#define DEFAULT_EFI_BLOB "BOOTX64.EFI"
+#else
+#define DEFAULT_EFI_BLOB "BOOTIA32.EFI"
+#endif
+
 typedef bool (*boot_loader_init)(const BootManager *);
 typedef bool (*boot_loader_install_kernel)(const BootManager *, const Kernel *);
 typedef bool (*boot_loader_remove_kernel)(const BootManager *, const Kernel *);

--- a/src/bootloaders/goofiboot.c
+++ b/src/bootloaders/goofiboot.c
@@ -15,8 +15,7 @@
 
 static BootLoaderConfig goofiboot_config = {.vendor_dir = "goofiboot",
                                             .efi_dir = "/usr/lib/goofiboot",
-                                            .x64_blob = "goofibootx64.efi",
-                                            .ia32_blob = "goofibootia32.efi",
+                                            .efi_blob = "goofiboot" SYSTEMD_EFI_SUFFIX,
                                             .name = "goofiboot" };
 
 static bool goofiboot_init(const BootManager *manager)

--- a/src/bootloaders/gummiboot.c
+++ b/src/bootloaders/gummiboot.c
@@ -15,8 +15,7 @@
 
 static BootLoaderConfig gummiboot_config = {.vendor_dir = "gummiboot",
                                             .efi_dir = "/usr/lib/gummiboot",
-                                            .x64_blob = "gummibootx64.efi",
-                                            .ia32_blob = "gummibootia32.efi",
+                                            .efi_blob = "gummiboot" SYSTEMD_EFI_SUFFIX,
                                             .name = "gummiboot" };
 
 static bool gummiboot_init(const BootManager *manager)

--- a/src/bootloaders/syslinux.c
+++ b/src/bootloaders/syslinux.c
@@ -27,6 +27,7 @@
 #include "files.h"
 #include "log.h"
 #include "nica/files.h"
+#include "system_stub.h"
 #include "util.h"
 #include "writer.h"
 
@@ -258,7 +259,7 @@ static bool syslinux_install(const BootManager *manager)
         close(mbr);
         close(syslinux_mbr);
 
-        if (system(extlinux_cmd) != 0) {
+        if (cbm_system_system(extlinux_cmd) != 0) {
                 return false;
         }
 

--- a/src/bootloaders/systemd-boot.c
+++ b/src/bootloaders/systemd-boot.c
@@ -15,8 +15,7 @@
 
 static BootLoaderConfig systemd_boot_config = {.vendor_dir = "systemd",
                                                .efi_dir = "/usr/lib/systemd/boot/efi",
-                                               .x64_blob = "systemd-bootx64.efi",
-                                               .ia32_blob = "systemd-bootia32.efi",
+                                               .efi_blob = "systemd-boot" SYSTEMD_EFI_SUFFIX,
                                                .name = "systemd-boot" };
 
 static bool systemd_boot_init(const BootManager *manager)

--- a/src/bootloaders/systemd-class.h
+++ b/src/bootloaders/systemd-class.h
@@ -16,11 +16,16 @@
 
 #pragma once
 
+#if UINTPTR_MAX == 0xffffffffffffffff
+#define SYSTEMD_EFI_SUFFIX "x64.efi"
+#else
+#define SYSTEMD_EFI_SUFFIX "ia32.efi"
+#endif
+
 typedef struct BootLoaderConfig {
         const char *vendor_dir;
         const char *efi_dir;
-        const char *x64_blob;
-        const char *ia32_blob;
+        const char *efi_blob;
         const char *name;
 } BootLoaderConfig;
 

--- a/src/bootman/bootman.c
+++ b/src/bootman/bootman.c
@@ -54,8 +54,7 @@ BootManager *boot_manager_new()
                 }
         }
 
-        /* CLI should override these */
-        boot_manager_set_can_mount(r, false);
+        /* CLI can override this */
         boot_manager_set_image_mode(r, false);
 
         return r;
@@ -430,18 +429,6 @@ bool boot_manager_set_uname(BootManager *self, const char *uname)
         memcpy(&(self->sys_kernel), &k, sizeof(struct SystemKernel));
         self->have_sys_kernel = have_sys_kernel;
         return self->have_sys_kernel;
-}
-
-void boot_manager_set_can_mount(BootManager *self, bool can_mount)
-{
-        assert(self != NULL);
-        self->can_mount = can_mount;
-}
-
-bool boot_manager_get_can_mount(BootManager *self)
-{
-        assert(self != NULL);
-        return self->can_mount;
 }
 
 /*

--- a/src/bootman/bootman.h
+++ b/src/bootman/bootman.h
@@ -331,16 +331,6 @@ Kernel *boot_manager_get_last_booted(BootManager *manager, KernelArray *kernels)
 bool cbm_parse_system_kernel(const char *inp, SystemKernel *kernel);
 
 /**
- * Set whether or not we can actually mount
- */
-void boot_manager_set_can_mount(BootManager *manager, bool can_mount);
-
-/**
- * Return a boolean indicating whether we can mount or not
- */
-bool boot_manager_get_can_mount(BootManager *manager);
-
-/**
  * Free a previously allocated sysconfig
  */
 void cbm_free_sysconfig(SystemConfig *config);

--- a/src/bootman/bootman_private.h
+++ b/src/bootman/bootman_private.h
@@ -31,7 +31,6 @@ struct BootManager {
         char *abs_bootdir;            /**<Real boot dir */
         SystemKernel sys_kernel;      /**<Native kernel info, if any */
         bool have_sys_kernel;         /**<Whether sys_kernel is set */
-        bool can_mount;               /**<Are we allowed to mount? */
         bool image_mode;              /**<Are we in image mode? */
         SystemConfig *sysconfig;      /**<System configuration */
         char *cmdline;                /**<Additional cmdline to append */

--- a/src/bootman/sysconfig.c
+++ b/src/bootman/sysconfig.c
@@ -41,6 +41,7 @@ SystemConfig *cbm_inspect_root(const char *path)
         SystemConfig *c = NULL;
         char *realp = NULL;
         char *boot = NULL;
+        char *rel = NULL;
 
         realp = realpath(path, NULL);
         if (!realp) {
@@ -56,33 +57,29 @@ SystemConfig *cbm_inspect_root(const char *path)
         }
         c->prefix = realp;
 
-        if (geteuid() == 0) {
-                char *rel = NULL;
-
-                /* Find legacy relative to root */
-                boot = get_legacy_boot_device(realp);
-                if (boot) {
-                        c->boot_device = boot;
-                        c->legacy = true;
-                        LOG_INFO("Discovered legacy boot device: %s", boot);
-                } else {
-                        c->boot_device = get_boot_device();
-                }
-
-                if (c->boot_device) {
-                        rel = realpath(c->boot_device, NULL);
-                        if (!rel) {
-                                LOG_FATAL("Cannot determine boot device: %s %s",
-                                          c->boot_device,
-                                          strerror(errno));
-                        } else {
-                                free(c->boot_device);
-                                c->boot_device = rel;
-                                LOG_INFO("Discovered boot device: %s", rel);
-                        }
-                }
-                c->root_device = cbm_probe_path(realp);
+        /* Find legacy relative to root */
+        boot = get_legacy_boot_device(realp);
+        if (boot) {
+                c->boot_device = boot;
+                c->legacy = true;
+                LOG_INFO("Discovered legacy boot device: %s", boot);
+        } else {
+                c->boot_device = get_boot_device();
         }
+
+        if (c->boot_device) {
+                rel = realpath(c->boot_device, NULL);
+                if (!rel) {
+                        LOG_FATAL("Cannot determine boot device: %s %s",
+                                  c->boot_device,
+                                  strerror(errno));
+                } else {
+                        free(c->boot_device);
+                        c->boot_device = rel;
+                        LOG_INFO("Discovered boot device: %s", rel);
+                }
+        }
+        c->root_device = cbm_probe_path(realp);
 
         return c;
 }

--- a/src/bootman/update.c
+++ b/src/bootman/update.c
@@ -48,6 +48,8 @@ bool boot_manager_update(BootManager *self)
         bool ret = false;
         autofree(char) *boot_dir = NULL;
         bool did_mount = false;
+        char *root_base = NULL;
+        autofree(char) *abs_bootdir = NULL;
 
         /* Image mode is very simple, no prep/cleanup */
         if (boot_manager_is_image_mode(self)) {
@@ -70,53 +72,49 @@ bool boot_manager_update(BootManager *self)
         }
 
         /* Prepare mounts */
-        if (boot_manager_get_can_mount(self)) {
-                LOG_INFO("Checking for mounted boot dir");
-                /* Already mounted at the default boot dir, nothing for us to do */
-                if (cbm_is_mounted(boot_dir, NULL)) {
-                        LOG_INFO("boot_dir is already mounted: %s", boot_dir);
-                        goto perform;
-                }
-                char *root_base = NULL;
-                autofree(char) *abs_bootdir = NULL;
-
-                /* Determine root device */
-                root_base = self->sysconfig->boot_device;
-                if (!root_base) {
-                        LOG_FATAL("Cannot determine boot device");
-                        return false;
-                }
-
-                abs_bootdir = cbm_get_mountpoint_for_device(root_base);
-
-                if (abs_bootdir) {
-                        LOG_DEBUG("Boot device already mounted at %s", abs_bootdir);
-                        /* User has already mounted the ESP somewhere else, use that */
-                        if (!boot_manager_set_boot_dir(self, abs_bootdir)) {
-                                LOG_FATAL("Cannot initialise with premounted ESP");
-                                return false;
-                        }
-                        /* Successfully using their premounted ESP, go use it */
-                        LOG_INFO("Skipping to native update");
-                        goto perform;
-                }
-
-                /* The boot directory isn't mounted, so we'll mount it now */
-                if (!nc_file_exists(boot_dir)) {
-                        LOG_INFO("Creating boot dir");
-                        nc_mkdir_p(boot_dir, 0755);
-                }
-                LOG_INFO("Mounting boot device %s at %s", root_base, boot_dir);
-                if (cbm_system_mount(root_base, boot_dir, "vfat", MS_MGC_VAL, "") < 0) {
-                        LOG_FATAL("FATAL: Cannot mount boot device %s on %s: %s",
-                                  root_base,
-                                  boot_dir,
-                                  strerror(errno));
-                        return false;
-                }
-                LOG_SUCCESS("%s successfully mounted at %s", root_base, boot_dir);
-                did_mount = true;
+        LOG_INFO("Checking for mounted boot dir");
+        /* Already mounted at the default boot dir, nothing for us to do */
+        if (cbm_is_mounted(boot_dir, NULL)) {
+                LOG_INFO("boot_dir is already mounted: %s", boot_dir);
+                goto perform;
         }
+
+        /* Determine root device */
+        root_base = self->sysconfig->boot_device;
+        if (!root_base) {
+                LOG_FATAL("Cannot determine boot device");
+                return false;
+        }
+
+        abs_bootdir = cbm_get_mountpoint_for_device(root_base);
+
+        if (abs_bootdir) {
+                LOG_DEBUG("Boot device already mounted at %s", abs_bootdir);
+                /* User has already mounted the ESP somewhere else, use that */
+                if (!boot_manager_set_boot_dir(self, abs_bootdir)) {
+                        LOG_FATAL("Cannot initialise with premounted ESP");
+                        return false;
+                }
+                /* Successfully using their premounted ESP, go use it */
+                LOG_INFO("Skipping to native update");
+                goto perform;
+        }
+
+        /* The boot directory isn't mounted, so we'll mount it now */
+        if (!nc_file_exists(boot_dir)) {
+                LOG_INFO("Creating boot dir");
+                nc_mkdir_p(boot_dir, 0755);
+        }
+        LOG_INFO("Mounting boot device %s at %s", root_base, boot_dir);
+        if (cbm_system_mount(root_base, boot_dir, "vfat", MS_MGC_VAL, "") < 0) {
+                LOG_FATAL("FATAL: Cannot mount boot device %s on %s: %s",
+                          root_base,
+                          boot_dir,
+                          strerror(errno));
+                return false;
+        }
+        LOG_SUCCESS("%s successfully mounted at %s", root_base, boot_dir);
+        did_mount = true;
 
 perform:
         /* Do a native update */

--- a/src/bootman/update.c
+++ b/src/bootman/update.c
@@ -22,6 +22,7 @@
 #include "files.h"
 #include "log.h"
 #include "nica/files.h"
+#include "system_stub.h"
 
 static bool boot_manager_update_image(BootManager *self);
 static bool boot_manager_update_native(BootManager *self);
@@ -106,7 +107,7 @@ bool boot_manager_update(BootManager *self)
                         nc_mkdir_p(boot_dir, 0755);
                 }
                 LOG_INFO("Mounting boot device %s at %s", root_base, boot_dir);
-                if (mount(root_base, boot_dir, "vfat", MS_MGC_VAL, "") < 0) {
+                if (cbm_system_mount(root_base, boot_dir, "vfat", MS_MGC_VAL, "") < 0) {
                         LOG_FATAL("FATAL: Cannot mount boot device %s on %s: %s",
                                   root_base,
                                   boot_dir,
@@ -124,7 +125,7 @@ perform:
         /* Cleanup and umount */
         if (did_mount) {
                 LOG_INFO("Attempting umount of %s", boot_dir);
-                if (umount(boot_dir) < 0) {
+                if (cbm_system_umount(boot_dir) < 0) {
                         LOG_WARNING("Could not unmount boot directory");
                 }
                 LOG_SUCCESS("Unmounted boot directory");

--- a/src/bootman/update.c
+++ b/src/bootman/update.c
@@ -74,7 +74,7 @@ bool boot_manager_update(BootManager *self)
         /* Prepare mounts */
         LOG_INFO("Checking for mounted boot dir");
         /* Already mounted at the default boot dir, nothing for us to do */
-        if (cbm_is_mounted(boot_dir, NULL)) {
+        if (cbm_system_is_mounted(boot_dir)) {
                 LOG_INFO("boot_dir is already mounted: %s", boot_dir);
                 goto perform;
         }
@@ -86,7 +86,7 @@ bool boot_manager_update(BootManager *self)
                 return false;
         }
 
-        abs_bootdir = cbm_get_mountpoint_for_device(root_base);
+        abs_bootdir = cbm_system_get_mountpoint_for_device(root_base);
 
         if (abs_bootdir) {
                 LOG_DEBUG("Boot device already mounted at %s", abs_bootdir);

--- a/src/cli/ops/update.c
+++ b/src/cli/ops/update.c
@@ -37,9 +37,6 @@ bool cbm_command_update(int argc, char **argv)
                 return false;
         }
 
-        /* Allow mounting of the ESP */
-        boot_manager_set_can_mount(manager, true);
-
         if (root) {
                 autofree(char) *realp = NULL;
 

--- a/src/lib/blkid_stub.c
+++ b/src/lib/blkid_stub.c
@@ -1,0 +1,169 @@
+/*
+ * This file is part of clr-boot-manager.
+ *
+ * Copyright © 2017 Intel Corporation
+ *
+ * clr-boot-manager is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ */
+
+#include "blkid_stub.h"
+
+#include <assert.h>
+#include <stdlib.h>
+
+/**
+ * Default blkid ops vtable passes through to libblkid itself
+ */
+static CbmBlkidOps default_blkid_ops = {
+        .probe_new_from_filename = blkid_new_probe_from_filename,
+        .probe_enable_superblocks = blkid_probe_enable_superblocks,
+        .probe_set_superblocks_flags = blkid_probe_set_superblocks_flags,
+        .probe_enable_partitions = blkid_probe_enable_partitions,
+        .probe_set_partitions_flags = blkid_probe_set_partitions_flags,
+        .probe_lookup_value = blkid_probe_lookup_value,
+        .do_safeprobe = blkid_do_safeprobe,
+        .free_probe = blkid_free_probe,
+
+        /* Partition functions */
+        .probe_get_partitions = blkid_probe_get_partitions,
+        .partlist_numof_partitions = blkid_partlist_numof_partitions,
+        .partlist_get_partition = blkid_partlist_get_partition,
+        .partition_get_flags = blkid_partition_get_flags,
+        .partition_get_uuid = blkid_partition_get_uuid,
+
+        /* Misc */
+        .devno_to_wholedisk = blkid_devno_to_wholedisk,
+};
+
+/**
+ * Pointer to the currently active vtable
+ */
+static CbmBlkidOps *blkid_ops = &default_blkid_ops;
+
+void cbm_blkid_reset_vtable(void)
+{
+        blkid_ops = &default_blkid_ops;
+}
+
+void cbm_blkid_set_vtable(CbmBlkidOps *ops)
+{
+        if (!ops) {
+                cbm_blkid_reset_vtable();
+        } else {
+                blkid_ops = ops;
+        }
+        /* Ensure the vtable is valid at this point. */
+        assert(blkid_ops->probe_new_from_filename != NULL);
+        assert(blkid_ops->probe_enable_superblocks != NULL);
+        assert(blkid_ops->probe_set_superblocks_flags != NULL);
+        assert(blkid_ops->probe_enable_partitions != NULL);
+        assert(blkid_ops->probe_set_partitions_flags != NULL);
+        assert(blkid_ops->probe_lookup_value != NULL);
+        assert(blkid_ops->do_safeprobe != NULL);
+        assert(blkid_ops->free_probe != NULL);
+
+        /* partition functions */
+        assert(blkid_ops->probe_get_partitions != NULL);
+        assert(blkid_ops->partlist_numof_partitions != NULL);
+        assert(blkid_ops->partlist_get_partition != NULL);
+        assert(blkid_ops->partition_get_flags != NULL);
+        assert(blkid_ops->partition_get_uuid != NULL);
+
+        /* misc */
+        assert(blkid_ops->devno_to_wholedisk != NULL);
+}
+
+/**
+ * Probe functions
+ */
+blkid_probe cbm_blkid_new_probe_from_filename(const char *filename)
+{
+        return blkid_ops->probe_new_from_filename(filename);
+}
+
+int cbm_blkid_probe_enable_superblocks(blkid_probe pr, int enable)
+{
+        return blkid_ops->probe_enable_superblocks(pr, enable);
+}
+
+int cbm_blkid_probe_set_superblocks_flags(blkid_probe pr, int flags)
+{
+        return blkid_ops->probe_set_superblocks_flags(pr, flags);
+}
+
+int cbm_blkid_probe_enable_partitions(blkid_probe pr, int enable)
+{
+        return blkid_ops->probe_enable_partitions(pr, enable);
+}
+
+int cbm_blkid_probe_set_partitions_flags(blkid_probe pr, int flags)
+{
+        return blkid_ops->probe_set_partitions_flags(pr, flags);
+}
+
+int cbm_blkid_do_safeprobe(blkid_probe pr)
+{
+        return blkid_ops->do_safeprobe(pr);
+}
+
+int cbm_blkid_probe_lookup_value(blkid_probe pr, const char *name, const char **data, size_t *len)
+{
+        return blkid_ops->probe_lookup_value(pr, name, data, len);
+}
+
+void cbm_blkid_free_probe(blkid_probe pr)
+{
+        blkid_ops->free_probe(pr);
+}
+
+/**
+ * Partition functions
+ */
+blkid_partlist cbm_blkid_probe_get_partitions(blkid_probe pr)
+{
+        return blkid_ops->probe_get_partitions(pr);
+}
+
+int cbm_blkid_partlist_numof_partitions(blkid_partlist ls)
+{
+        return blkid_ops->partlist_numof_partitions(ls);
+}
+
+blkid_partition cbm_blkid_partlist_get_partition(blkid_partlist ls, int n)
+{
+        return blkid_ops->partlist_get_partition(ls, n);
+}
+
+unsigned long long cbm_blkid_partition_get_flags(blkid_partition par)
+{
+        return blkid_ops->partition_get_flags(par);
+}
+
+const char *cbm_blkid_partition_get_uuid(blkid_partition par)
+{
+        return blkid_ops->partition_get_uuid(par);
+}
+
+/**
+ * Misc functions
+ */
+int cbm_blkid_devno_to_wholedisk(dev_t dev, char *diskname, size_t len, dev_t *diskdevno)
+{
+        return blkid_ops->devno_to_wholedisk(dev, diskname, len, diskdevno);
+}
+
+/*
+ * Editor modelines  -  https://www.wireshark.org/tools/modelines.html
+ *
+ * Local variables:
+ * c-basic-offset: 8
+ * tab-width: 8
+ * indent-tabs-mode: nil
+ * End:
+ *
+ * vi: set shiftwidth=8 tabstop=8 expandtab:
+ * :indentSize=8:tabSize=8:noTabs=true:
+ */

--- a/src/lib/blkid_stub.h
+++ b/src/lib/blkid_stub.h
@@ -1,0 +1,124 @@
+/*
+ * This file is part of clr-boot-manager.
+ *
+ * Copyright © 2017 Intel Corporation
+ *
+ * clr-boot-manager is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ */
+
+#pragma once
+
+#define _GNU_SOURCE
+#include <blkid.h>
+
+/**
+ * Defines the vtable used for all blkid operations within clr-boot-manager.
+ * The default internal vtable will pass through all operations to libblkid.
+ */
+typedef struct CbmBlkidOps {
+        /* Probe functions */
+        blkid_probe (*probe_new_from_filename)(const char *filename);
+        int (*probe_enable_superblocks)(blkid_probe pr, int enable);
+        int (*probe_set_superblocks_flags)(blkid_probe pr, int flags);
+        int (*probe_enable_partitions)(blkid_probe pr, int enable);
+        int (*probe_set_partitions_flags)(blkid_probe pr, int flags);
+        int (*probe_lookup_value)(blkid_probe pr, const char *name, const char **data, size_t *len);
+        int (*do_safeprobe)(blkid_probe pr);
+        void (*free_probe)(blkid_probe pr);
+
+        /* Partition functions */
+        blkid_partlist (*probe_get_partitions)(blkid_probe pr);
+        int (*partlist_numof_partitions)(blkid_partlist ls);
+        blkid_partition (*partlist_get_partition)(blkid_partlist ls, int n);
+        unsigned long long (*partition_get_flags)(blkid_partition par);
+        const char *(*partition_get_uuid)(blkid_partition par);
+
+        /* Misc functions */
+        int (*devno_to_wholedisk)(dev_t dev, char *diskname, size_t len, dev_t *diskdevno);
+} CbmBlkidOps;
+
+/**
+ * Define an empty blkid_probe for testing
+ */
+#define CBM_BLKID_PROBE_NULL ((blkid_probe)0)
+
+/**
+ * Define a "set" blkid_probe for testing
+ */
+#define CBM_BLKID_PROBE_SET ((blkid_probe)1)
+
+/**
+ * Define an empty blkid_partlist for testing
+ */
+#define CBM_BLKID_PARTLIST_NULL ((blkid_partlist)0)
+
+/**
+ * Define a "set" blkid_partlist for testing
+ */
+#define CBM_BLKID_PARTLIST_SET ((blkid_partlist)1)
+
+/**
+ * Define an empty blkid_partition for testing
+ */
+#define CBM_BLKID_PARTITION_NULL ((blkid_partition)0)
+
+/**
+ * Define a "set" blkid_partition for testing
+ */
+#define CBM_BLKID_PARTITION_SET ((blkid_partition)1)
+
+/**
+ * Reset the blkid vtable
+ */
+void cbm_blkid_reset_vtable(void);
+
+/**
+ * Set the vfunc table used for all blkid operations within clr-boot-manager
+ *
+ * @note Passing null has the same effect as calling cbm_blkid_reset
+ * The vtable will be checked to ensure that it is valid at this point, so
+ * only call this when the vtable is fully populated.
+ */
+void cbm_blkid_set_vtable(CbmBlkidOps *ops);
+
+/**
+ * Probe related wrappers
+ */
+blkid_probe cbm_blkid_new_probe_from_filename(const char *filename);
+int cbm_blkid_probe_enable_superblocks(blkid_probe pr, int enable);
+int cbm_blkid_probe_set_superblocks_flags(blkid_probe pr, int flags);
+int cbm_blkid_probe_enable_partitions(blkid_probe pr, int enable);
+int cbm_blkid_probe_set_partitions_flags(blkid_probe pr, int flags);
+int cbm_blkid_do_safeprobe(blkid_probe pr);
+int cbm_blkid_probe_lookup_value(blkid_probe pr, const char *name, const char **data, size_t *len);
+void cbm_blkid_free_probe(blkid_probe pr);
+
+/**
+ * Partition related wrappers
+ */
+blkid_partlist cbm_blkid_probe_get_partitions(blkid_probe pr);
+int cbm_blkid_partlist_numof_partitions(blkid_partlist ls);
+blkid_partition cbm_blkid_partlist_get_partition(blkid_partlist ls, int n);
+unsigned long long cbm_blkid_partition_get_flags(blkid_partition par);
+const char *cbm_blkid_partition_get_uuid(blkid_partition par);
+
+/**
+ * Misc related wrappers
+ */
+int cbm_blkid_devno_to_wholedisk(dev_t dev, char *diskname, size_t len, dev_t *diskdevno);
+
+/*
+ * Editor modelines  -  https://www.wireshark.org/tools/modelines.html
+ *
+ * Local variables:
+ * c-basic-offset: 8
+ * tab-width: 8
+ * indent-tabs-mode: nil
+ * End:
+ *
+ * vi: set shiftwidth=8 tabstop=8 expandtab:
+ * :indentSize=8:tabSize=8:noTabs=true:
+ */

--- a/src/lib/files.c
+++ b/src/lib/files.c
@@ -386,22 +386,15 @@ bool copy_file_atomic(const char *src, const char *target, mode_t mode)
         return true;
 }
 
-bool cbm_is_mounted(const char *path, bool *error)
+bool cbm_is_mounted(const char *path)
 {
         autofree(FILE_MNT) *tab = NULL;
         struct mntent *ent = NULL;
         struct mntent mnt = { 0 };
         char buf[8192];
 
-        if (error) {
-                *error = false;
-        }
-
         tab = setmntent("/proc/self/mounts", "r");
         if (!tab) {
-                if (error) {
-                        *error = true;
-                }
                 return false;
         }
 

--- a/src/lib/files.h
+++ b/src/lib/files.h
@@ -128,7 +128,7 @@ bool copy_file_atomic(const char *src, const char *dst, mode_t mode);
  *
  * @param path Path to test is mounted or not
  */
-bool cbm_is_mounted(const char *path, bool *error);
+bool cbm_is_mounted(const char *path);
 
 /**
  * Determine the mountpoint for the given device

--- a/src/lib/log.c
+++ b/src/lib/log.c
@@ -31,28 +31,17 @@ void cbm_log_init(FILE *log)
 {
         const char *env_level = NULL;
         log_file = log;
+        int nlog_level = CBM_LOG_ERROR;
 
         env_level = getenv("CBM_DEBUG");
-        if (!env_level) {
-                min_log_level = CBM_LOG_ERROR;
-                return;
+        if (env_level) {
+                /* =1 becomes 0 */
+                nlog_level = atoi(env_level) - 1;
         }
-
-        if (streq(env_level, "1")) {
-                min_log_level = CBM_LOG_DEBUG;
-        } else if (streq(env_level, "2")) {
-                min_log_level = CBM_LOG_INFO;
-        } else if (streq(env_level, "3")) {
-                min_log_level = CBM_LOG_SUCCESS;
-        } else if (streq(env_level, "4")) {
-                min_log_level = CBM_LOG_ERROR;
-        } else if (streq(env_level, "5")) {
-                min_log_level = CBM_LOG_WARNING;
-        } else if (streq(env_level, "6")) {
-                min_log_level = CBM_LOG_FATAL;
-        } else {
-                min_log_level = CBM_LOG_ERROR;
+        if (nlog_level < CBM_LOG_DEBUG || nlog_level >= CBM_LOG_MAX) {
+                nlog_level = CBM_LOG_FATAL;
         }
+        min_log_level = nlog_level;
 }
 
 /**

--- a/src/lib/log.h
+++ b/src/lib/log.h
@@ -21,7 +21,8 @@ typedef enum {
         CBM_LOG_SUCCESS,
         CBM_LOG_ERROR,
         CBM_LOG_WARNING,
-        CBM_LOG_FATAL
+        CBM_LOG_FATAL,
+        CBM_LOG_MAX /* Unused */
 } CbmLogLevel;
 
 /**

--- a/src/lib/probe.c
+++ b/src/lib/probe.c
@@ -11,7 +11,6 @@
 
 #define _GNU_SOURCE
 
-#include <blkid.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <glob.h>
@@ -22,6 +21,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include "blkid_stub.h"
 #include "log.h"
 #include "probe.h"
 #include "util.h"
@@ -96,24 +96,24 @@ static char *cbm_get_luks_uuid(const char *part)
                 return NULL;
         }
 
-        blk_probe = blkid_new_probe_from_filename(dpath);
+        blk_probe = cbm_blkid_new_probe_from_filename(dpath);
         if (!blk_probe) {
                 LOG_ERROR("Unable to probe %s", dpath);
                 return NULL;
         }
 
-        blkid_probe_enable_superblocks(blk_probe, 1);
-        blkid_probe_set_superblocks_flags(blk_probe, BLKID_SUBLKS_TYPE | BLKID_SUBLKS_UUID);
-        blkid_probe_enable_partitions(blk_probe, 1);
-        blkid_probe_set_partitions_flags(blk_probe, BLKID_PARTS_ENTRY_DETAILS);
+        cbm_blkid_probe_enable_superblocks(blk_probe, 1);
+        cbm_blkid_probe_set_superblocks_flags(blk_probe, BLKID_SUBLKS_TYPE | BLKID_SUBLKS_UUID);
+        cbm_blkid_probe_enable_partitions(blk_probe, 1);
+        cbm_blkid_probe_set_partitions_flags(blk_probe, BLKID_PARTS_ENTRY_DETAILS);
 
-        if (blkid_do_safeprobe(blk_probe) != 0) {
+        if (cbm_blkid_do_safeprobe(blk_probe) != 0) {
                 LOG_ERROR("Error probing filesystem: %s", strerror(errno));
                 goto clean;
         }
 
         /* Grab the type */
-        if (blkid_probe_lookup_value(blk_probe, "TYPE", &value, NULL) != 0) {
+        if (cbm_blkid_probe_lookup_value(blk_probe, "TYPE", &value, NULL) != 0) {
                 LOG_ERROR("Error determining type of device %s: %s\n", dpath, strerror(errno));
                 goto clean;
         }
@@ -123,7 +123,7 @@ static char *cbm_get_luks_uuid(const char *part)
                 goto clean;
         }
 
-        if (blkid_probe_lookup_value(blk_probe, "UUID", &value, NULL) == 0) {
+        if (cbm_blkid_probe_lookup_value(blk_probe, "UUID", &value, NULL) == 0) {
                 ret = strdup(value);
                 if (!ret) {
                         DECLARE_OOM();
@@ -132,7 +132,7 @@ static char *cbm_get_luks_uuid(const char *part)
         }
 
 clean:
-        blkid_free_probe(blk_probe);
+        cbm_blkid_free_probe(blk_probe);
         return ret;
 }
 
@@ -162,23 +162,23 @@ CbmDeviceProbe *cbm_probe_path(const char *path)
                 return NULL;
         }
 
-        blk_probe = blkid_new_probe_from_filename(devnode);
+        blk_probe = cbm_blkid_new_probe_from_filename(devnode);
         if (!blk_probe) {
                 fprintf(stderr, "Unable to probe %u:%u", major(st.st_dev), minor(st.st_dev));
                 return NULL;
         }
 
-        blkid_probe_enable_superblocks(blk_probe, 1);
-        blkid_probe_set_superblocks_flags(blk_probe, BLKID_SUBLKS_TYPE | BLKID_SUBLKS_UUID);
-        blkid_probe_enable_partitions(blk_probe, 1);
-        blkid_probe_set_partitions_flags(blk_probe, BLKID_PARTS_ENTRY_DETAILS);
+        cbm_blkid_probe_enable_superblocks(blk_probe, 1);
+        cbm_blkid_probe_set_superblocks_flags(blk_probe, BLKID_SUBLKS_TYPE | BLKID_SUBLKS_UUID);
+        cbm_blkid_probe_enable_partitions(blk_probe, 1);
+        cbm_blkid_probe_set_partitions_flags(blk_probe, BLKID_PARTS_ENTRY_DETAILS);
 
-        if (blkid_do_safeprobe(blk_probe) != 0) {
+        if (cbm_blkid_do_safeprobe(blk_probe) != 0) {
                 LOG_ERROR("Error probing filesystem: %s", strerror(errno));
                 goto clean;
         }
 
-        if (blkid_probe_lookup_value(blk_probe, "PART_ENTRY_UUID", &value, NULL) == 0) {
+        if (cbm_blkid_probe_lookup_value(blk_probe, "PART_ENTRY_UUID", &value, NULL) == 0) {
                 probe.part_uuid = strdup(value);
                 if (!probe.part_uuid) {
                         DECLARE_OOM();
@@ -186,7 +186,7 @@ CbmDeviceProbe *cbm_probe_path(const char *path)
                 }
         }
 
-        if (blkid_probe_lookup_value(blk_probe, "UUID", &value, NULL) == 0) {
+        if (cbm_blkid_probe_lookup_value(blk_probe, "UUID", &value, NULL) == 0) {
                 probe.uuid = strdup(value);
                 if (!probe.uuid) {
                         DECLARE_OOM();
@@ -213,7 +213,7 @@ CbmDeviceProbe *cbm_probe_path(const char *path)
         *ret = probe;
 
 clean:
-        blkid_free_probe(blk_probe);
+        cbm_blkid_free_probe(blk_probe);
         return ret;
 }
 

--- a/src/lib/system_stub.c
+++ b/src/lib/system_stub.c
@@ -1,0 +1,75 @@
+/*
+ * This file is part of clr-boot-manager.
+ *
+ * Copyright © 2017 Intel Corporation
+ *
+ * clr-boot-manager is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ */
+
+#include "system_stub.h"
+
+#include <assert.h>
+#include <stdlib.h>
+#include <sys/mount.h>
+
+/**
+ * Default vtable for system call passthrough
+ */
+static CbmSystemOps default_system_ops = {
+        .mount = mount, .umount = umount, .system = system,
+};
+
+/**
+ * Pointer to the currently active vtable
+ */
+static CbmSystemOps *system_ops = &default_system_ops;
+
+void cbm_system_reset_vtable(void)
+{
+        system_ops = &default_system_ops;
+}
+
+void cbm_system_set_vtable(CbmSystemOps *ops)
+{
+        if (!ops) {
+                cbm_system_reset_vtable();
+        } else {
+                system_ops = ops;
+        }
+        /* Ensure the vtable is valid at this point. */
+        assert(system_ops->mount != NULL);
+        assert(system_ops->umount != NULL);
+        assert(system_ops->system != NULL);
+}
+
+int cbm_system_mount(const char *source, const char *target, const char *filesystemtype,
+                     unsigned long mountflags, const void *data)
+{
+        return system_ops->mount(source, target, filesystemtype, mountflags, data);
+}
+
+int cbm_system_umount(const char *target)
+{
+        return system_ops->umount(target);
+}
+
+int cbm_system_system(const char *command)
+{
+        return system_ops->system(command);
+}
+
+/*
+ * Editor modelines  -  https://www.wireshark.org/tools/modelines.html
+ *
+ * Local variables:
+ * c-basic-offset: 8
+ * tab-width: 8
+ * indent-tabs-mode: nil
+ * End:
+ *
+ * vi: set shiftwidth=8 tabstop=8 expandtab:
+ * :indentSize=8:tabSize=8:noTabs=true:
+ */

--- a/src/lib/system_stub.c
+++ b/src/lib/system_stub.c
@@ -15,12 +15,17 @@
 #include <stdlib.h>
 #include <sys/mount.h>
 
+#include "files.h"
+
 /**
  * Default vtable for system call passthrough
  */
-static CbmSystemOps default_system_ops = {
-        .mount = mount, .umount = umount, .system = system,
-};
+static CbmSystemOps default_system_ops = {.mount = mount,
+                                          .umount = umount,
+                                          .system = system,
+                                          .is_mounted = cbm_is_mounted,
+                                          .get_mountpoint_for_device =
+                                              cbm_get_mountpoint_for_device };
 
 /**
  * Pointer to the currently active vtable
@@ -42,6 +47,8 @@ void cbm_system_set_vtable(CbmSystemOps *ops)
         /* Ensure the vtable is valid at this point. */
         assert(system_ops->mount != NULL);
         assert(system_ops->umount != NULL);
+        assert(system_ops->is_mounted != NULL);
+        assert(system_ops->get_mountpoint_for_device != NULL);
         assert(system_ops->system != NULL);
 }
 
@@ -59,6 +66,16 @@ int cbm_system_umount(const char *target)
 int cbm_system_system(const char *command)
 {
         return system_ops->system(command);
+}
+
+bool cbm_system_is_mounted(const char *target)
+{
+        return system_ops->is_mounted(target);
+}
+
+char *cbm_system_get_mountpoint_for_device(const char *device)
+{
+        return system_ops->get_mountpoint_for_device(device);
 }
 
 /*

--- a/src/lib/system_stub.h
+++ b/src/lib/system_stub.h
@@ -1,0 +1,72 @@
+/*
+ * This file is part of clr-boot-manager.
+ *
+ * Copyright © 2017 Intel Corporation
+ *
+ * clr-boot-manager is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ */
+
+#pragma once
+
+#define _GNU_SOURCE
+
+/**
+ * Defines the vtable used for all systen operations within clr-boot-manager.
+ * The default internal vtable will pass through all operations to the standard
+ * library.
+ */
+typedef struct CbmSystemOps {
+        /* fs functions */
+        int (*mount)(const char *source, const char *target, const char *filesystemtype,
+                     unsigned long mountflags, const void *data);
+        int (*umount)(const char *target);
+
+        /* exec family */
+        int (*system)(const char *command);
+} CbmSystemOps;
+
+/**
+ * Reset the system vtable
+ */
+void cbm_system_reset_vtable(void);
+
+/**
+ * Set the vfunc table used for all system operations within clr-boot-manager
+ *
+ * @note Passing null has the same effect as calling cbm_system_reset
+ * The vtable will be checked to ensure that it is valid at this point, so
+ * only call this when the vtable is fully populated.
+ */
+void cbm_system_set_vtable(CbmSystemOps *ops);
+
+/**
+ * Wrap the mount syscall
+ */
+int cbm_system_mount(const char *source, const char *target, const char *filesystemtype,
+                     unsigned long mountflags, const void *data);
+
+/**
+ * Wrap the umount syscall
+ */
+int cbm_system_umount(const char *target);
+
+/**
+ * Wrap the system() call
+ */
+int cbm_system_system(const char *command);
+
+/*
+ * Editor modelines  -  https://www.wireshark.org/tools/modelines.html
+ *
+ * Local variables:
+ * c-basic-offset: 8
+ * tab-width: 8
+ * indent-tabs-mode: nil
+ * End:
+ *
+ * vi: set shiftwidth=8 tabstop=8 expandtab:
+ * :indentSize=8:tabSize=8:noTabs=true:
+ */

--- a/src/lib/system_stub.h
+++ b/src/lib/system_stub.h
@@ -13,6 +13,8 @@
 
 #define _GNU_SOURCE
 
+#include <stdbool.h>
+
 /**
  * Defines the vtable used for all systen operations within clr-boot-manager.
  * The default internal vtable will pass through all operations to the standard
@@ -23,6 +25,10 @@ typedef struct CbmSystemOps {
         int (*mount)(const char *source, const char *target, const char *filesystemtype,
                      unsigned long mountflags, const void *data);
         int (*umount)(const char *target);
+
+        /* wrap cbm lib functions */
+        bool (*is_mounted)(const char *target);
+        char *(*get_mountpoint_for_device)(const char *device);
 
         /* exec family */
         int (*system)(const char *command);
@@ -47,6 +53,16 @@ void cbm_system_set_vtable(CbmSystemOps *ops);
  */
 int cbm_system_mount(const char *source, const char *target, const char *filesystemtype,
                      unsigned long mountflags, const void *data);
+
+/**
+ * Determine if the given mount point is already mounted
+ */
+bool cbm_system_is_mounted(const char *target);
+
+/**
+ * Get the mountpoint for the given device path
+ */
+char *cbm_system_get_mountpoint_for_device(const char *device);
 
 /**
  * Wrap the umount syscall

--- a/tests/blkid-harness.h
+++ b/tests/blkid-harness.h
@@ -1,0 +1,157 @@
+/*
+ * This file is part of clr-boot-manager.
+ *
+ * Copyright © 2016-2017 Intel Corporation
+ *
+ * clr-boot-manager is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ */
+
+#pragma once
+
+#include "blkid_stub.h"
+
+const char *DEFAULT_UUID = "Test-UUID";
+const char *DEFAULT_PART_UUID = "Test-PartUUID";
+
+/**
+ * Probe functions
+ */
+static inline blkid_probe test_blkid_new_probe_from_filename(__cbm_unused__ const char *filename)
+{
+        return CBM_BLKID_PROBE_SET;
+}
+
+static inline int test_blkid_probe_enable_superblocks(__cbm_unused__ blkid_probe pr,
+                                                      __cbm_unused__ int enable)
+{
+        return 0;
+}
+
+static inline int test_blkid_probe_set_superblocks_flags(__cbm_unused__ blkid_probe pr,
+                                                         __cbm_unused__ int flags)
+{
+        return 0;
+}
+
+static inline int test_blkid_probe_enable_partitions(__cbm_unused__ blkid_probe pr,
+                                                     __cbm_unused__ int enable)
+{
+        return 0;
+}
+
+static inline int test_blkid_probe_set_partitions_flags(__cbm_unused__ blkid_probe pr,
+                                                        __cbm_unused__ int flags)
+{
+        return 0;
+}
+
+static inline int test_blkid_do_safeprobe(__cbm_unused__ blkid_probe pr)
+{
+        return 0;
+}
+
+static inline int test_blkid_probe_lookup_value(__cbm_unused__ blkid_probe pr, const char *name,
+                                                const char **data, size_t *len)
+{
+        if (!name || !data) {
+                return -1;
+        }
+        if (streq(name, "UUID")) {
+                *data = DEFAULT_UUID;
+        } else if (streq(name, "PART_ENTRY_UUID")) {
+                *data = DEFAULT_PART_UUID;
+        } else {
+                return -1;
+        }
+        if (!*data) {
+                abort();
+        }
+        if (len) {
+                *len = strlen(*data);
+        }
+        return 0;
+}
+
+static inline void test_blkid_free_probe(__cbm_unused__ blkid_probe pr)
+{
+}
+
+/**
+ * Partition functions
+ */
+static inline blkid_partlist test_blkid_probe_get_partitions(__cbm_unused__ blkid_probe pr)
+{
+        return CBM_BLKID_PARTLIST_SET;
+}
+
+static inline int test_blkid_partlist_numof_partitions(__cbm_unused__ blkid_partlist ls)
+{
+        return 2;
+}
+
+static inline blkid_partition test_blkid_partlist_get_partition(__cbm_unused__ blkid_partlist ls,
+                                                                __cbm_unused__ int n)
+{
+        return CBM_BLKID_PARTITION_SET;
+}
+
+static inline unsigned long long test_blkid_partition_get_flags(__cbm_unused__ blkid_partition par)
+{
+        /* Prevents legacy testing */
+        return 0;
+}
+
+static inline const char *test_blkid_partition_get_uuid(__cbm_unused__ blkid_partition par)
+{
+        return NULL;
+}
+
+static inline int test_blkid_devno_to_wholedisk(__cbm_unused__ dev_t dev,
+                                                __cbm_unused__ char *diskname,
+                                                __cbm_unused__ size_t len,
+                                                __cbm_unused__ dev_t *diskdevno)
+{
+        /* Prevent legacy testing */
+        return -1;
+}
+
+/**
+ * Default vtable for testing. Copy into a local struct and override specific
+ * fields.
+ */
+CbmBlkidOps BlkidTestOps = {
+        .probe_new_from_filename = test_blkid_new_probe_from_filename,
+        .probe_enable_superblocks = test_blkid_probe_enable_superblocks,
+        .probe_set_superblocks_flags = test_blkid_probe_set_superblocks_flags,
+        .probe_enable_partitions = test_blkid_probe_enable_partitions,
+        .probe_set_partitions_flags = test_blkid_probe_set_partitions_flags,
+        .probe_lookup_value = test_blkid_probe_lookup_value,
+        .do_safeprobe = test_blkid_do_safeprobe,
+        .free_probe = test_blkid_free_probe,
+
+        /* Partition functions */
+        .probe_get_partitions = test_blkid_probe_get_partitions,
+        .partlist_numof_partitions = test_blkid_partlist_numof_partitions,
+        .partlist_get_partition = test_blkid_partlist_get_partition,
+        .partition_get_flags = test_blkid_partition_get_flags,
+        .partition_get_uuid = test_blkid_partition_get_uuid,
+
+        /* Misc */
+        .devno_to_wholedisk = test_blkid_devno_to_wholedisk,
+};
+
+/*
+ * Editor modelines  -  https://www.wireshark.org/tools/modelines.html
+ *
+ * Local variables:
+ * c-basic-offset: 8
+ * tab-width: 8
+ * indent-tabs-mode: nil
+ * End:
+ *
+ * vi: set shiftwidth=8 tabstop=8 expandtab:
+ * :indentSize=8:tabSize=8:noTabs=true:
+ */

--- a/tests/check-core.c
+++ b/tests/check-core.c
@@ -28,6 +28,7 @@
 
 #include "blkid-harness.h"
 #include "harness.h"
+#include "system-harness.h"
 
 static PlaygroundKernel core_kernels[] = { { "4.2.1", "kvm", 121, false },
                                            { "4.2.3", "kvm", 124, true },
@@ -635,6 +636,7 @@ int main(void)
         cbm_log_init(stderr);
 
         cbm_blkid_set_vtable(&BlkidTestOps);
+        cbm_system_set_vtable(&SystemTestOps);
 
         s = core_suite();
         sr = srunner_create(s);

--- a/tests/check-core.c
+++ b/tests/check-core.c
@@ -26,6 +26,7 @@
 #include "util.h"
 #include "writer.h"
 
+#include "blkid-harness.h"
 #include "harness.h"
 
 static PlaygroundKernel core_kernels[] = { { "4.2.1", "kvm", 121, false },
@@ -632,6 +633,8 @@ int main(void)
         /* Ensure that logging is set up properly. */
         setenv("CBM_DEBUG", "1", 1);
         cbm_log_init(stderr);
+
+        cbm_blkid_set_vtable(&BlkidTestOps);
 
         s = core_suite();
         sr = srunner_create(s);

--- a/tests/check-files.c
+++ b/tests/check-files.c
@@ -75,8 +75,8 @@ START_TEST(bootman_mount_test)
                 LOG_INFO("Skipping mount test as /proc/self/mounts is absent");
                 return;
         }
-        fail_if(!cbm_is_mounted("/", NULL), "Apparently / not mounted. Question physics.");
-        fail_if(cbm_is_mounted("/,^roflcopter", NULL),
+        fail_if(!cbm_is_mounted("/"), "Apparently / not mounted. Question physics.");
+        fail_if(cbm_is_mounted("/,^roflcopter"),
                 "Non-existent path mounted. Or you have a genuinely weird path");
 }
 END_TEST

--- a/tests/check-updates.c
+++ b/tests/check-updates.c
@@ -24,6 +24,7 @@
 #include "log.h"
 #include "nica/files.h"
 
+#include "blkid-harness.h"
 #include "config.h"
 #include "harness.h"
 
@@ -290,6 +291,9 @@ int main(void)
         /* Ensure that logging is set up properly. */
         setenv("CBM_DEBUG", "1", 1);
         cbm_log_init(stderr);
+
+        /* Override vtable for safety */
+        cbm_blkid_set_vtable(&BlkidTestOps);
 
         s = core_suite();
         sr = srunner_create(s);

--- a/tests/check-updates.c
+++ b/tests/check-updates.c
@@ -27,6 +27,7 @@
 #include "blkid-harness.h"
 #include "config.h"
 #include "harness.h"
+#include "system-harness.h"
 
 START_TEST(bootman_image_test_simple)
 {
@@ -294,6 +295,7 @@ int main(void)
 
         /* Override vtable for safety */
         cbm_blkid_set_vtable(&BlkidTestOps);
+        cbm_system_set_vtable(&SystemTestOps);
 
         s = core_suite();
         sr = srunner_create(s);

--- a/tests/harness.c
+++ b/tests/harness.c
@@ -444,7 +444,6 @@ BootManager *prepare_playground(PlaygroundConfig *config)
                 }
         }
 
-        boot_manager_set_can_mount(m, false);
         boot_manager_set_image_mode(m, false);
         if (config->uts_name && !boot_manager_set_uname(m, config->uts_name)) {
                 fprintf(stderr, "Cannot set given uname of %s\n", config->uts_name);

--- a/tests/system-harness.h
+++ b/tests/system-harness.h
@@ -1,0 +1,53 @@
+/*
+ * This file is part of clr-boot-manager.
+ *
+ * Copyright © 2016-2017 Intel Corporation
+ *
+ * clr-boot-manager is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ */
+
+#pragma once
+
+#include "system_stub.h"
+
+static inline int test_mount(__cbm_unused__ const char *source, __cbm_unused__ const char *target,
+                             __cbm_unused__ const char *filesystemtype,
+                             __cbm_unused__ unsigned long mountflags,
+                             __cbm_unused__ const void *data)
+{
+        return 0;
+}
+
+static inline int test_umount(__cbm_unused__ const char *target)
+{
+        return 0;
+}
+
+static inline int test_system(__cbm_unused__ const char *command)
+{
+        return 0;
+}
+
+/**
+ * Default vtable for testing. Copy into a local struct and override specific
+ * fields.
+ */
+CbmSystemOps SystemTestOps = {
+        .mount = test_mount, .umount = test_umount, .system = test_system,
+};
+
+/*
+ * Editor modelines  -  https://www.wireshark.org/tools/modelines.html
+ *
+ * Local variables:
+ * c-basic-offset: 8
+ * tab-width: 8
+ * indent-tabs-mode: nil
+ * End:
+ *
+ * vi: set shiftwidth=8 tabstop=8 expandtab:
+ * :indentSize=8:tabSize=8:noTabs=true:
+ */

--- a/tests/system-harness.h
+++ b/tests/system-harness.h
@@ -31,13 +31,25 @@ static inline int test_system(__cbm_unused__ const char *command)
         return 0;
 }
 
+static inline bool test_is_mounted(__cbm_unused__ const char *target)
+{
+        return false;
+}
+
+static inline char *test_get_mountpoint_for_device(__cbm_unused__ const char *device)
+{
+        return NULL;
+}
+
 /**
  * Default vtable for testing. Copy into a local struct and override specific
  * fields.
  */
-CbmSystemOps SystemTestOps = {
-        .mount = test_mount, .umount = test_umount, .system = test_system,
-};
+CbmSystemOps SystemTestOps = {.mount = test_mount,
+                              .umount = test_umount,
+                              .system = test_system,
+                              .is_mounted = test_is_mounted,
+                              .get_mountpoint_for_device = test_get_mountpoint_for_device };
 
 /*
  * Editor modelines  -  https://www.wireshark.org/tools/modelines.html


### PR DESCRIPTION
All of these changes are designed to do two things:

 - Significantly raise coverage
 - Unblock testing of `syslinux` (and future `GRUB`) with vfunc tables

Old cruft has been fixed and underped (unused parameters, etc) and support for `CONFIG_EFI_MIXED` removed as `systemd` doesn't actually support it still.