### PR TITLE
Ensure to include sysmacros.h for major/minor usage

### DIFF
--- a/src/lib/blkid_stub.c
+++ b/src/lib/blkid_stub.c
@@ -14,6 +14,7 @@
 #include <assert.h>
 #include <stdbool.h>
 #include <stdlib.h>
+#include <sys/sysmacros.h>
 
 /**
  * Ensure we check here for the blkid device being correct.

--- a/src/lib/files.c
+++ b/src/lib/files.c
@@ -26,6 +26,7 @@
 #include <sys/mman.h>
 #include <sys/sendfile.h>
 #include <sys/stat.h>
+#include <sys/sysmacros.h>
 #include <unistd.h>
 
 #include "blkid_stub.h"

--- a/src/lib/probe.c
+++ b/src/lib/probe.c
@@ -19,6 +19,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
+#include <sys/sysmacros.h>
 #include <unistd.h>
 
 #include "blkid_stub.h"

--- a/src/lib/system_stub.c
+++ b/src/lib/system_stub.c
@@ -14,6 +14,7 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <sys/mount.h>
+#include <sys/sysmacros.h>
 
 #include "files.h"
 #include "log.h"

--- a/tests/check-legacy.c
+++ b/tests/check-legacy.c
@@ -15,6 +15,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <sys/sysmacros.h>
 
 #include "bootman.h"
 #include "config.h"

--- a/tests/check-probe.c
+++ b/tests/check-probe.c
@@ -31,6 +31,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <sys/sysmacros.h>
 
 #include "blkid_stub.h"
 #include "bootloader.h"

--- a/tests/check-select-bootloader.c
+++ b/tests/check-select-bootloader.c
@@ -28,6 +28,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <sys/sysmacros.h>
 
 #include "bootloader.h"
 #include "bootman.h"


### PR DESCRIPTION
As of glibc 2.25, warnings will be emitted at compile time to state
that you must explicitly include the header now, due to libraries
tending to have their own definitions.

Signed-off-by: Ikey Doherty <michael.i.doherty@intel.com>