### PR TITLE
kernel: Allow lack of modules to be non-fatal

### DIFF
--- a/src/bootman/kernel.c
+++ b/src/bootman/kernel.c
@@ -122,8 +122,9 @@ Kernel *boot_manager_inspect_kernel(BootManager *self, char *path)
                                            release);
 
                 if (!nc_file_exists(module_dir)) {
-                        LOG_ERROR("Valid kernel with no modules: %s %s", path, module_dir);
-                        return NULL;
+                        LOG_WARNING("Found kernel with no modules: %s %s", path, module_dir);
+                        free(module_dir);
+                        module_dir = NULL;
                 }
         }
 
@@ -143,7 +144,9 @@ Kernel *boot_manager_inspect_kernel(BootManager *self, char *path)
         kern->source.path = strdup(path);
         kern->meta.bpath = strdup(bcp);
         kern->meta.version = strdup(version);
-        kern->source.module_dir = strdup(module_dir);
+        if (module_dir) {
+                kern->source.module_dir = strdup(module_dir);
+        }
         kern->meta.ktype = strdup(type);
         /* Legacy path should be used by non-UEFI bootloaders */
         kern->target.legacy_path = kern->meta.bpath;

--- a/tests/harness.h
+++ b/tests/harness.h
@@ -35,6 +35,7 @@ typedef struct PlaygroundConfig {
         PlaygroundKernel *initial_kernels;
         size_t n_kernels;
         bool uefi;
+        bool disable_modules; /* Whether we want modules or not */
 } PlaygroundConfig;
 
 /**
@@ -46,7 +47,7 @@ BootManager *prepare_playground(PlaygroundConfig *config);
 /**
  * Push a new kernel into the root
  */
-bool push_kernel_update(PlaygroundKernel *kernel);
+bool push_kernel_update(PlaygroundConfig *config, PlaygroundKernel *kernel);
 
 /**
  * Set the current kernel as the default for it's type, overriding any


### PR DESCRIPTION
The lack of kernel modules during install isn't necessarily fatal, and
some kernel configurations might be without modules entirely. Notably,
given that kernel modules are to be marked as resident on disk, even if
we have multiple packages compromising a kernel and separate modules, those
old modules will be removed at the time of the kernel change, and at no
other time, ensuring an atomic update.

This resolves #67.

Signed-off-by: Ikey Doherty <michael.i.doherty@intel.com>