### PR TITLE
Minor code cleanup

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8,6 +8,9 @@ AM_SILENT_RULES([yes])
 AC_CONFIG_MACRO_DIR([m4])
 AX_VALGRIND_CHECK
 LT_INIT
+# Avoid long-hanging warning of using 'u' (in the automake's default 'cru') with
+# ar's default 'D'. Specify complete set of modifiers explicitly.
+AC_SUBST(AR_FLAGS, [crD])
 
 # Unit tests
 PKG_CHECK_MODULES([CHECK], [check >= 0.9])

--- a/src/bootman/kernel.c
+++ b/src/bootman/kernel.c
@@ -396,7 +396,7 @@ bool cbm_parse_system_kernel(const char *inp, SystemKernel *kernel)
         if (c - inp >= CBM_KELEM_LEN) {
                 return false;
         }
-        if (c + 1 == '\0') {
+        if (*(c + 1) == '\0') {
                 return false;
         }
         c2 = strchr(c + 1, '.');


### PR DESCRIPTION
Two issues minor issues addressed. One is to get rid of build-time warning when archiving static libraries, the other one is incorrect comparison (forgotten dereference of a `char *`).