### PR TITLE
lib: Address upstream util-linux partlist regression

### DIFF
--- a/src/lib/blkid_stub.c
+++ b/src/lib/blkid_stub.c
@@ -151,6 +151,9 @@ blkid_partlist cbm_blkid_probe_get_partitions(blkid_probe pr)
 
 int cbm_blkid_partlist_numof_partitions(blkid_partlist ls)
 {
+        if (!ls) {
+                return 0;
+        }
         return blkid_ops->partlist_numof_partitions(ls);
 }
 


### PR DESCRIPTION
This fixes a segfault occuring within clr-boot-manager's usage of the
`blkid_partlist_numof_partitions` function that will now segfault when
passed a NULL blkid_partlist, as of util-linux 2.30.x series.

This change will ensure all consumers of the cbm_blkid API will continue to
function as before, but safe guard against the util-linux internal changes
that broke the counter function to determine how many partitions are present.

Note that this behaviour only manifested on LVM installations, which have
a more advanced probing scheme within clr-boot-manager.

Solus Issue: https://dev.solus-project.com/T4763

Signed-off-by: Ikey Doherty <ikey@solus-project.com>