### PR TITLE
Fix mem mgmt issues introduced by shim-systemd.

### DIFF
--- a/src/bootloaders/bootloader.h
+++ b/src/bootloaders/bootloader.h
@@ -21,7 +21,7 @@
 
 typedef bool (*boot_loader_init)(const BootManager *);
 typedef bool (*boot_loader_install_kernel)(const BootManager *, const Kernel *);
-typedef char *(*boot_loader_get_kernel_destination)(const BootManager *);
+typedef const char *(*boot_loader_get_kernel_destination)(const BootManager *);
 typedef bool (*boot_loader_remove_kernel)(const BootManager *, const Kernel *);
 typedef bool (*boot_loader_set_default_kernel)(const BootManager *, const Kernel *kernel);
 typedef bool (*boot_loader_needs_update)(const BootManager *);

--- a/src/bootloaders/systemd-class.c
+++ b/src/bootloaders/systemd-class.c
@@ -44,7 +44,7 @@ typedef struct SdClassConfig {
 static SdClassConfig sd_class_config = { 0 };
 static BootLoaderConfig *sd_config = NULL;
 
-static char *(*get_kernel_destination_impl)(const BootManager *);
+static const char *(*get_kernel_destination_impl)(const BootManager *);
 
 #define FREE_IF_SET(x)                                                                             \
         {                                                                                          \
@@ -54,9 +54,9 @@ static char *(*get_kernel_destination_impl)(const BootManager *);
                 }                                                                                  \
         }
 
-char *sd_class_get_kernel_destination_default(__cbm_unused__ const BootManager *manager)
+const char *sd_class_get_kernel_destination_default(__cbm_unused__ const BootManager *manager)
 {
-        return strdup(sd_class_config.kernel_dir);
+        return sd_class_config.kernel_dir;
 }
 
 bool sd_class_init(const BootManager *manager, BootLoaderConfig *config)
@@ -127,12 +127,12 @@ bool sd_class_init(const BootManager *manager, BootLoaderConfig *config)
         return true;
 }
 
-void sd_class_set_get_kernel_destination_impl(char *(*impl)(const BootManager *))
+void sd_class_set_get_kernel_destination_impl(const char *(*impl)(const BootManager *))
 {
         get_kernel_destination_impl = impl;
 }
 
-char *sd_class_get_kernel_destination(const BootManager *manager)
+const char *sd_class_get_kernel_destination(const BootManager *manager)
 {
         return get_kernel_destination_impl(manager);
 }

--- a/src/bootloaders/systemd-class.h
+++ b/src/bootloaders/systemd-class.h
@@ -29,7 +29,7 @@ typedef struct BootLoaderConfig {
         const char *name;
 } BootLoaderConfig;
 
-char *sd_class_get_kernel_destination(const BootManager *manager);
+const char *sd_class_get_kernel_destination(const BootManager *manager);
 
 bool sd_class_install_kernel(const BootManager *manager, const Kernel *kernel);
 

--- a/src/bootman/kernel.c
+++ b/src/bootman/kernel.c
@@ -594,7 +594,7 @@ bool boot_manager_install_kernel_internal(const BootManager *manager, const Kern
         const char *initrd_source = NULL;
         bool is_uefi = ((manager->bootloader->get_capabilities(manager) & BOOTLOADER_CAP_UEFI) ==
                         BOOTLOADER_CAP_UEFI);
-        autofree(char) *efi_boot_dir =
+        const char *efi_boot_dir =
             is_uefi ? manager->bootloader->get_kernel_destination(manager) : NULL;
 
         assert(manager != NULL);
@@ -669,7 +669,7 @@ bool boot_manager_remove_kernel_internal(const BootManager *manager, const Kerne
         autofree(char) *initrd_target = NULL;
         bool is_uefi = ((manager->bootloader->get_capabilities(manager) & BOOTLOADER_CAP_UEFI) ==
                         BOOTLOADER_CAP_UEFI);
-        autofree(char) *efi_boot_dir =
+        const char *efi_boot_dir =
             is_uefi ? manager->bootloader->get_kernel_destination(manager) : NULL;
 
         assert(manager != NULL);

--- a/tests/harness.c
+++ b/tests/harness.c
@@ -480,9 +480,9 @@ int kernel_installed_files_count(BootManager *manager, PlaygroundKernel *kernel)
         autofree(char) *initrd_file = NULL;
         autofree(char) *initrd_file_legacy = NULL;
         /* where the kernel files are expected to be found on the ESP */
-        char *esp_path = manager->bootloader->get_kernel_destination
-                             ? manager->bootloader->get_kernel_destination(manager)
-                             : "efi/" KERNEL_NAMESPACE;
+        const char *esp_path = manager->bootloader->get_kernel_destination
+                                   ? manager->bootloader->get_kernel_destination(manager)
+                                   : "efi/" KERNEL_NAMESPACE;
         const char *vendor = NULL;
         int file_count = 0;
 


### PR DESCRIPTION
Refactor the API slightly to reflect the intended use of
get_kernel_destination() function of the bootloader.

Fix plain memory management issues.