### PR TITLE
Fix kernel destination dir in systemd-boot.

### DIFF
--- a/src/bootloaders/systemd-class.c
+++ b/src/bootloaders/systemd-class.c
@@ -175,6 +175,10 @@ static char *get_entry_path_for_kernel(BootManager *manager, const Kernel *kerne
 
 static bool sd_class_ensure_dirs(void)
 {
+        autofree(char) *kernel_destination_path = nc_build_case_correct_path(sd_class_config.base_path,
+                                                                             sd_class_config.kernel_dir,
+                                                                             NULL);
+
         if (!nc_mkdir_p(sd_class_config.efi_dir, 00755)) {
                 LOG_FATAL("Failed to create %s: %s", sd_class_config.efi_dir, strerror(errno));
                 return false;
@@ -183,6 +187,12 @@ static bool sd_class_ensure_dirs(void)
 
         if (!nc_mkdir_p(sd_class_config.vendor_dir, 00755)) {
                 LOG_FATAL("Failed to create %s: %s", sd_class_config.vendor_dir, strerror(errno));
+                return false;
+        }
+        cbm_sync();
+
+        if (!nc_mkdir_p(kernel_destination_path, 00755)) {
+                LOG_FATAL("Failed to create %s: %s", kernel_destination_path, strerror(errno));
                 return false;
         }
         cbm_sync();

--- a/tests/check-uefi.c
+++ b/tests/check-uefi.c
@@ -263,7 +263,7 @@ START_TEST(bootman_uefi_remove_bootloader)
         autofree(BootManager) *m = NULL;
 
         fail_if(!nc_file_exists(TOP_BUILD_DIR "/tests/update_playground/" BOOT_DIRECTORY
-                                              "/efi/BOOT"),
+                                              "/EFI/Boot"),
                 "Main EFI directory missing, botched install");
 
         m = prepare_playground(&uefi_config);
@@ -281,19 +281,19 @@ START_TEST(bootman_uefi_remove_bootloader)
 
         /* Ensure that it is indeed removed. */
         fail_if(nc_file_exists(TOP_BUILD_DIR "/tests/update_playground" BOOT_DIRECTORY
-                                             "/efi/BOOT" DEFAULT_EFI_BLOB),
+                                             "/EFI/Boot" DEFAULT_EFI_BLOB),
                 "Main x64 bootloader present");
 #if defined(HAVE_SYSTEMD_BOOT)
         fail_if(nc_file_exists(TOP_BUILD_DIR "/tests/update_playground/" BOOT_DIRECTORY
-                                             "/efi/systemd"),
+                                             "/EFI/systemd"),
                 "Systemd x64 bootloader present");
 #elif defined(HAVE_GUMMIBOOT)
         fail_if(nc_file_exists(TOP_BUILD_DIR "/tests/update_playground/" BOOT_DIRECTORY
-                                             "/efi/gummiboot"),
+                                             "/EFI/gummiboot"),
                 "gummiboot x64 bootloader present");
 #else
         fail_if(nc_file_exists(TOP_BUILD_DIR "/tests/update_playground/" BOOT_DIRECTORY
-                                             "/efi/goofiboot"),
+                                             "/EFI/goofiboot"),
                 "goofiboot x64 bootloader present");
 #endif
 

--- a/tests/harness.c
+++ b/tests/harness.c
@@ -49,11 +49,11 @@
  */
 #define BOOT_FULL PLAYGROUND_ROOT "/" BOOT_DIRECTORY
 
-#define EFI_START BOOT_FULL "/efi"
+#define EFI_START BOOT_FULL "/EFI"
 /**
  * i.e. $dir/EFI/Boot/BOOTX64.EFI
  */
-#define EFI_STUB_MAIN BOOT_FULL "/efi/BOOT/BOOT" EFI_STUB_SUFFIX
+#define EFI_STUB_MAIN BOOT_FULL "/EFI/Boot/BOOT" EFI_STUB_SUFFIX
 
 /**
  * Places that need to exist..
@@ -437,7 +437,7 @@ BootManager *prepare_playground(PlaygroundConfig *config)
                 }
                 /* Create dir *after* init to simulate ESP mount behaviour with
                  * a different-case boot tree on the ESP */
-                fail_if(!nc_mkdir_p(EFI_START "/BOOT", 00755), "Failed to create boot structure");
+                fail_if(!nc_mkdir_p(EFI_START "/Boot", 00755), "Failed to create boot structure");
         } else {
                 push_syslinux();
         }
@@ -482,7 +482,7 @@ int kernel_installed_files_count(BootManager *manager, PlaygroundKernel *kernel)
         /* where the kernel files are expected to be found on the ESP */
         const char *esp_path = manager->bootloader->get_kernel_destination
                                    ? manager->bootloader->get_kernel_destination(manager)
-                                   : "efi/" KERNEL_NAMESPACE;
+                                   : "EFI/" KERNEL_NAMESPACE;
         const char *vendor = NULL;
         int file_count = 0;
 


### PR DESCRIPTION
kernel.c no longer creates any layout, but systemd-class was not
creating/ensuring kernel target directory either. This fixes the issue.

Also, tests are fixed to use proper ESP standard names throughout.