### PR TITLE
Fixes case-intolerance in file names. Restores divergent names in tests.

### DIFF
--- a/tests/check-uefi.c
+++ b/tests/check-uefi.c
@@ -263,7 +263,7 @@ START_TEST(bootman_uefi_remove_bootloader)
         autofree(BootManager) *m = NULL;
 
         fail_if(!nc_file_exists(TOP_BUILD_DIR "/tests/update_playground/" BOOT_DIRECTORY
-                                              "/EFI/Boot"),
+                                              "/efi/BOOT"),
                 "Main EFI directory missing, botched install");
 
         m = prepare_playground(&uefi_config);
@@ -281,19 +281,19 @@ START_TEST(bootman_uefi_remove_bootloader)
 
         /* Ensure that it is indeed removed. */
         fail_if(nc_file_exists(TOP_BUILD_DIR "/tests/update_playground" BOOT_DIRECTORY
-                                             "/EFI/Boot" DEFAULT_EFI_BLOB),
+                                             "/efi/BOOT" DEFAULT_EFI_BLOB),
                 "Main x64 bootloader present");
 #if defined(HAVE_SYSTEMD_BOOT)
         fail_if(nc_file_exists(TOP_BUILD_DIR "/tests/update_playground/" BOOT_DIRECTORY
-                                             "/EFI/systemd"),
+                                             "/efi/systemd"),
                 "Systemd x64 bootloader present");
 #elif defined(HAVE_GUMMIBOOT)
         fail_if(nc_file_exists(TOP_BUILD_DIR "/tests/update_playground/" BOOT_DIRECTORY
-                                             "/EFI/gummiboot"),
+                                             "/efi/gummiboot"),
                 "gummiboot x64 bootloader present");
 #else
         fail_if(nc_file_exists(TOP_BUILD_DIR "/tests/update_playground/" BOOT_DIRECTORY
-                                             "/EFI/goofiboot"),
+                                             "/efi/goofiboot"),
                 "goofiboot x64 bootloader present");
 #endif
 

--- a/tests/check-uefi.c
+++ b/tests/check-uefi.c
@@ -202,6 +202,14 @@ END_TEST
 static void internal_loader_test(bool image_mode)
 {
         autofree(BootManager) *m = NULL;
+        bool installs_default_bootloader = true;
+#if defined(HAVE_SHIM_SYSTEMD_BOOT)
+        installs_default_bootloader = false;
+#endif
+        /* whether the harness needs to check the default bootloader match.
+         * shim-systemd is the only exception, it only installs the default
+         * bootloader in the image mode. */
+        bool check_default_bootloader = installs_default_bootloader || image_mode;
         PlaygroundConfig start_conf = {.uefi = true };
 
         m = prepare_playground(&start_conf);
@@ -212,17 +220,17 @@ static void internal_loader_test(bool image_mode)
                 "Failed to install bootloader");
 
         confirm_bootloader();
-        fail_if(!confirm_bootloader_match(), "Installed bootloader is incorrect");
+        fail_if(!confirm_bootloader_match(check_default_bootloader), "Installed bootloader is incorrect");
 
         fail_if(!push_bootloader_update(1), "Failed to bump source bootloader");
-        fail_if(confirm_bootloader_match(), "Source shouldn't match target bootloader yet");
+        fail_if(confirm_bootloader_match(check_default_bootloader), "Source shouldn't match target bootloader yet");
 
         fail_if(!boot_manager_modify_bootloader(m,
                                                 BOOTLOADER_OPERATION_UPDATE |
                                                     BOOTLOADER_OPERATION_NO_CHECK),
                 "Failed to forcibly update bootloader");
         confirm_bootloader();
-        fail_if(!confirm_bootloader_match(), "Bootloader didn't actually update");
+        fail_if(!confirm_bootloader_match(check_default_bootloader), "Bootloader didn't actually update");
 
         /* We're in sync */
         fail_if(boot_manager_needs_update(m), "Bootloader lied about needing an update");
@@ -232,7 +240,7 @@ static void internal_loader_test(bool image_mode)
         fail_if(!boot_manager_needs_update(m), "Bootloader doesn't know it needs update");
         fail_if(!boot_manager_modify_bootloader(m, BOOTLOADER_OPERATION_UPDATE),
                 "Failed to auto-update bootloader");
-        fail_if(!confirm_bootloader_match(), "Auto-updated bootloader doesn't match source");
+        fail_if(!confirm_bootloader_match(check_default_bootloader), "Auto-updated bootloader doesn't match source");
 }
 
 START_TEST(bootman_uefi_update_image)

--- a/tests/harness.c
+++ b/tests/harness.c
@@ -139,14 +139,14 @@ void confirm_bootloader(void)
         fail_if(!noisy_file_exists(ESP_BOOT_STUB), "ESP target stub missing");
 }
 
-bool confirm_bootloader_match(void)
+bool confirm_bootloader_match(bool check_default)
 {
-#if !defined(HAVE_SHIM_SYSTEMD_BOOT)
-        if (!cbm_files_match(BOOT_COPY_TARGET, EFI_STUB_MAIN)) {
-                fprintf(stderr, "EFI_STUB_MAIN doesn't match the source\n");
-                return false;
+        if (check_default) {
+                if (!cbm_files_match(BOOT_COPY_TARGET, EFI_STUB_MAIN)) {
+                        fprintf(stderr, "EFI_STUB_MAIN doesn't match the source\n");
+                        return false;
+                }
         }
-#endif /* !HAVE_SHIM_SYSTEMD_BOOT */
         if (!cbm_files_match(BOOT_COPY_TARGET, ESP_BOOT_STUB)) {
                 fprintf(stderr, "ESP_BOOT_STUB(vendor) doesn't match the source\n");
                 return false;

--- a/tests/harness.c
+++ b/tests/harness.c
@@ -49,11 +49,11 @@
  */
 #define BOOT_FULL PLAYGROUND_ROOT "/" BOOT_DIRECTORY
 
-#define EFI_START BOOT_FULL "/EFI"
+#define EFI_START BOOT_FULL "/efi"
 /**
  * i.e. $dir/EFI/Boot/BOOTX64.EFI
  */
-#define EFI_STUB_MAIN BOOT_FULL "/EFI/Boot/BOOT" EFI_STUB_SUFFIX
+#define EFI_STUB_MAIN BOOT_FULL "/efi/BOOT/BOOT" EFI_STUB_SUFFIX
 
 /**
  * Places that need to exist..
@@ -64,7 +64,7 @@
  */
 #if defined(HAVE_SYSTEMD_BOOT)
 #if defined(HAVE_SHIM_SYSTEMD_BOOT)
-#define ESP_BOOT_DIR BOOT_FULL "/EFI/" KERNEL_NAMESPACE
+#define ESP_BOOT_DIR BOOT_FULL "/efi/" KERNEL_NAMESPACE
 #define ESP_BOOT_STUB ESP_BOOT_DIR "/bootloader" EFI_STUB_SUFFIX_L
 #define SHIM_BOOT_COPY_DIR PLAYGROUND_ROOT "/usr/lib/shim"
 #else
@@ -437,7 +437,7 @@ BootManager *prepare_playground(PlaygroundConfig *config)
                 }
                 /* Create dir *after* init to simulate ESP mount behaviour with
                  * a different-case boot tree on the ESP */
-                fail_if(!nc_mkdir_p(EFI_START "/Boot", 00755), "Failed to create boot structure");
+                fail_if(!nc_mkdir_p(EFI_START "/BOOT", 00755), "Failed to create boot structure");
         } else {
                 push_syslinux();
         }
@@ -482,7 +482,7 @@ int kernel_installed_files_count(BootManager *manager, PlaygroundKernel *kernel)
         /* where the kernel files are expected to be found on the ESP */
         const char *esp_path = manager->bootloader->get_kernel_destination
                                    ? manager->bootloader->get_kernel_destination(manager)
-                                   : "EFI/" KERNEL_NAMESPACE;
+                                   : "efi/" KERNEL_NAMESPACE;
         const char *vendor = NULL;
         int file_count = 0;
 

--- a/tests/harness.h
+++ b/tests/harness.h
@@ -82,9 +82,11 @@ void confirm_bootloader(void);
 int kernel_installed_files_count(BootManager *manager, PlaygroundKernel *kernel);
 
 /**
- * Util - confirm the bootloader installed matches the source file
+ * Util - confirm the bootloader installed matches the source file. If
+ * check_default is true, also checks the default bootloader
+ * (/EFI/Boot/BOOT<ARCH>.efi)
  */
-bool confirm_bootloader_match(void);
+bool confirm_bootloader_match(bool check_default);
 
 /**
  * Assert that the kernel is fully installed


### PR DESCRIPTION
Both systemd-class and shim-systemd are fixed in separate commits.

Addresses the concerns raised in #88.

CC: @bryteise, @ikeydoherty 