### PR TITLE
 Portability support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/libnica"]
 	path = src/libnica
-	url = https://github.com/ikeydoherty/libnica.git
+	url = https://github.com/intel/libnica.git

--- a/src/bootloaders/shim-systemd.c
+++ b/src/bootloaders/shim-systemd.c
@@ -11,7 +11,7 @@
 
 #define _GNU_SOURCE
 
-#include <linux/limits.h>
+#include <limits.h>
 
 #include "bootloader.h"
 #include "bootman.h"

--- a/src/bootman/kernel.c
+++ b/src/bootman/kernel.c
@@ -15,6 +15,7 @@
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <limits.h>
 #include <unistd.h>
 
 #include "bootman.h"


### PR DESCRIPTION
This initial change makes sure our codebase is more portable and doesn't depend too much on GNUisms like `#include <linux...`.