### PR TITLE
Add documentation to man page for kernel configuration

### DIFF
--- a/man/clr-boot-manager.1.in
+++ b/man/clr-boot-manager.1.in
@@ -93,6 +93,19 @@ Returns the currently configured timeout as set by \fBclr\-boot\-manager set\-ti
 .PP
 On success, 0 is returned, a non\-zero failure code otherwise\&
 
+.SH "CONFIGURATION"
+.PP
+clr-boot-manager takes into account the following paths to modify its behavior:
+
+.PP
+\fB@KERNEL_CONF_DIRECTORY@/cmdline.d/*.conf\fR
+.RS 4
+A set of files that will be used to modify the kernel commandline. The files
+can also be used to mask the vendor cmdline if the filename matches a vendor
+configuration file and is linked to /dev/null\&.
+.RE
+
+
 .SH "ENVIRONMENT"
 \fI$CBM_DEBUG\fR
 .RS 4

--- a/man/meson.build
+++ b/man/meson.build
@@ -1,6 +1,14 @@
 mandir = join_paths(path_prefix, get_option('mandir'), 'man1')
 
+# Update man page with paths
+man_data = configuration_data()
+man_data.set('KERNEL_CONF_DIRECTORY', with_kernel_conf_dir)
+man_1 = configure_file(input : 'clr-boot-manager.1.in',
+                       output : 'clr-boot-manager.1',
+                       configuration : man_data,
+)
+
 install_data(
-    'clr-boot-manager.1',
+    man_1,
     install_dir: mandir,
 )


### PR DESCRIPTION
Update man page to describe the use of the kernel configuration files
that can be modified by the system administrator to set the kernel
commandline.