### PR TITLE
clr-boot-manager: add support initrd no kernel dep

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -116,10 +116,22 @@ if with_kernel_dir == ''
     with_kernel_dir = join_paths(path_prefix, 'lib', 'kernel')
 endif
 
+# Defaults to /usr/lib/initrd.d
+with_initrd_dir = get_option('with-initrd-dir')
+if with_initrd_dir == ''
+    with_initrd_dir = join_paths(path_prefix, 'lib', 'initrd.d')
+endif
+
 # Defaults to /etc/kernel
 with_kernel_conf_dir = get_option('with-kernel-conf-dir')
 if with_kernel_conf_dir == ''
     with_kernel_conf_dir = join_paths(path_sysconfdir, 'kernel')
+endif
+
+# Defaults to /etc/initrd.d
+with_initrd_user_dir = get_option('with-initrd-user-dir')
+if with_initrd_user_dir == ''
+    with_initrd_user_dir = join_paths(path_sysconfdir, 'initrd.d')
 endif
 
 # Defaults to /usr/lib/modules
@@ -153,11 +165,13 @@ endif
 
 # Set config.h options up for our general directories, etc.
 cdata.set_quoted('KERNEL_DIRECTORY', with_kernel_dir)
+cdata.set_quoted('INITRD_DIRECTORY', with_initrd_dir)
 cdata.set_quoted('KERNEL_MODULES_DIRECTORY', with_kernel_modules_dir)
 cdata.set_quoted('KERNEL_NAMESPACE', with_kernel_namespace)
 cdata.set_quoted('BOOT_DIRECTORY', with_boot_dir)
 cdata.set_quoted('VENDOR_PREFIX', with_vendor_prefix)
 cdata.set_quoted('KERNEL_CONF_DIRECTORY', with_kernel_conf_dir)
+cdata.set_quoted('INITRD_USER_DIRECTORY', with_initrd_user_dir)
 cdata.set_quoted('VENDOR_KERNEL_CONF_DIRECTORY', with_kernel_vendor_conf_dir)
 
 # Helps the test suites

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -13,6 +13,10 @@ option('with-kernel-modules-dir', type: 'string', description: 'System kernel mo
 option('with-kernel-namespace', type: 'string', description: 'Identifier for boot assets', value: 'org.clearlinux')
 option('with-kernel-vendor-conf-dir', type: 'string', description: 'Vendor kernel configuration directory')
 
+# Initrd options
+option('with-initrd-dir', type: 'string', description: 'Vendor initrd without kernel dependency directory')
+option('with-initrd-user-dir', type: 'string', description: 'User initrd without kernel dependency directory')
+
 # General options
 option('with-boot-dir', type: 'string', description: 'System boot directory', value: '/boot')
 option('with-vendor-prefix', type: 'string', description: 'Prefix for files created by clr-boot-manager', value: 'generic-linux-os')

--- a/src/bootloaders/systemd-class.c
+++ b/src/bootloaders/systemd-class.c
@@ -247,6 +247,10 @@ bool sd_class_install_kernel(const BootManager *manager, const Kernel *kernel)
                                          get_kernel_destination_impl(manager),
                                          kernel->target.initrd_path);
         }
+
+        /* Optional initrd no deps */
+        boot_manager_write_initrd_nodep(manager, writer);
+
         /* Add the root= section */
         if (root_dev->part_uuid) {
                 cbm_writer_append_printf(writer, "options root=PARTUUID=%s ", root_dev->part_uuid);

--- a/src/bootman/bootman.c
+++ b/src/bootman/bootman.c
@@ -96,6 +96,8 @@ void boot_manager_free(BootManager *self)
 
         cbm_free_sysconfig(self->sysconfig);
         free(self->kernel_dir);
+        free(self->initrd_nodep_dir);
+        nc_array_free(&self->nodep_initrd, free);
         free(self->abs_bootdir);
         free(self->cmdline);
         free(self);
@@ -146,6 +148,7 @@ bool boot_manager_set_prefix(BootManager *self, char *prefix)
         assert(self != NULL);
 
         char *kernel_dir = NULL;
+        char *initrd_dir = NULL;
         SystemConfig *config = NULL;
 
         if (!prefix) {
@@ -172,6 +175,14 @@ bool boot_manager_set_prefix(BootManager *self, char *prefix)
                 free(self->kernel_dir);
         }
         self->kernel_dir = kernel_dir;
+
+        initrd_dir = string_printf("%s/%s", config->prefix, INITRD_DIRECTORY);
+
+        if (self->initrd_nodep_dir) {
+                free(self->initrd_nodep_dir);
+                self->initrd_nodep_dir = NULL;
+        }
+        self->initrd_nodep_dir = initrd_dir;
 
         if (self->bootloader) {
                 self->bootloader->destroy(self);

--- a/src/bootman/bootman.h
+++ b/src/bootman/bootman.h
@@ -15,6 +15,7 @@
 #include "nica/hashmap.h"
 #include "probe.h"
 #include "util.h"
+#include "writer.h"
 
 typedef struct BootManager BootManager;
 
@@ -77,6 +78,8 @@ typedef struct Kernel {
 } Kernel;
 
 typedef NcArray KernelArray;
+
+typedef NcArray NoDepInitrdArray;
 
 /**
  * Represenative of the system configuration of a given target prefix.
@@ -349,6 +352,26 @@ static inline void kernel_array_free(void *v)
         KernelArray *a = v;
         nc_array_free(&a, (array_free_func)free_kernel);
 }
+
+/**
+ * Get initrds without kernel dependeny
+ */
+NoDepInitrdArray *boot_manager_get_nodeps_initrd(BootManager *self);
+
+/**
+ * Copy initrds without kernel dependeny to boot partition
+ */
+bool boot_manager_copy_initrd_nodep(BootManager *self);
+
+/**
+ * Remove old initrds without kernel dependency
+ */
+void boot_manager_remove_nodeps_initrd(BootManager * self);
+
+/**
+ * Write old initrds without kernel dependency in entry of bool conf
+ */
+void boot_manager_write_initrd_nodep(const BootManager *manager, CbmWriter *writer);
 
 DEF_AUTOFREE(BootManager, boot_manager_free)
 DEF_AUTOFREE(KernelArray, kernel_array_free)

--- a/src/bootman/bootman_private.h
+++ b/src/bootman/bootman_private.h
@@ -26,6 +26,7 @@
 
 struct BootManager {
         char *kernel_dir;             /**<Kernel directory */
+        char *initrd_nodep_dir;       /**<Initrd without kernel deps directory */
         const BootLoader *bootloader; /**<Selected bootloader */
         CbmOsRelease *os_release;     /**<Parsed os-release file */
         char *abs_bootdir;            /**<Real boot dir */
@@ -34,6 +35,7 @@ struct BootManager {
         bool image_mode;              /**<Are we in image mode? */
         SystemConfig *sysconfig;      /**<System configuration */
         char *cmdline;                /**<Additional cmdline to append */
+        NoDepInitrdArray *nodep_initrd;/**<Array of initrds without kernel deps */
 };
 
 /**

--- a/src/bootman/update.c
+++ b/src/bootman/update.c
@@ -251,6 +251,9 @@ static bool boot_manager_update_native(BootManager *self)
                 return false;
         }
 
+        /* Grab the available initrd without kernel deps */
+        self->nodep_initrd = boot_manager_get_nodeps_initrd(self);
+
         LOG_DEBUG("update_native: %d available kernels", kernels->len);
 
         /* Get them sorted */
@@ -297,6 +300,10 @@ static bool boot_manager_update_native(BootManager *self)
                         LOG_SUCCESS("update_native: Repaired running kernel %s",
                                     running->source.path);
                 }
+        }
+
+        if (!boot_manager_copy_initrd_nodep(self)) {
+                goto cleanup;
         }
 
         nc_hashmap_iter_init(mapped_kernels, &map_iter);
@@ -420,6 +427,7 @@ static bool boot_manager_update_native(BootManager *self)
 
         ret = true;
 
+        boot_manager_remove_nodeps_initrd(self);
         if (!removals) {
                 /* We're done. */
                 LOG_DEBUG("No kernel removals found");


### PR DESCRIPTION
add suport for initrds without kernel dependencies in /usr/lib/initrd.d
just for systemd-boot at the moment

Signed-off-by: Josue David Hernandez <josue.d.hernandez.gutierrez@intel.com>