### PR TITLE
clr-boot-manager: add support initrd no kernel dep

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,8 @@ addons:
 before_install:
   - gem install coveralls-lcov
   - mkdir -p $HOME/prefix/bin
-  - pip3 install --user meson==0.42.1
-  - wget https://github.com/ninja-build/ninja/releases/download/v1.6.0/ninja-linux.zip
+  - pip3 install --user meson==0.44.1
+  - wget https://github.com/ninja-build/ninja/releases/download/v1.8.2/ninja-linux.zip
   - unzip ninja-linux.zip
   - mv ninja $HOME/prefix/bin/
 

--- a/meson.build
+++ b/meson.build
@@ -116,6 +116,12 @@ if with_kernel_dir == ''
     with_kernel_dir = join_paths(path_prefix, 'lib', 'kernel')
 endif
 
+# Defaults to /usr/lib/initrd.d
+with_initrd_dir = get_option('with-initrd-dir')
+if with_initrd_dir == ''
+    with_initrd_dir = join_paths(path_prefix, 'lib', 'initrd.d')
+endif
+
 # Defaults to /etc/kernel
 with_kernel_conf_dir = get_option('with-kernel-conf-dir')
 if with_kernel_conf_dir == ''
@@ -153,6 +159,7 @@ endif
 
 # Set config.h options up for our general directories, etc.
 cdata.set_quoted('KERNEL_DIRECTORY', with_kernel_dir)
+cdata.set_quoted('INITRD_DIRECTORY', with_initrd_dir)
 cdata.set_quoted('KERNEL_MODULES_DIRECTORY', with_kernel_modules_dir)
 cdata.set_quoted('KERNEL_NAMESPACE', with_kernel_namespace)
 cdata.set_quoted('BOOT_DIRECTORY', with_boot_dir)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -13,6 +13,9 @@ option('with-kernel-modules-dir', type: 'string', description: 'System kernel mo
 option('with-kernel-namespace', type: 'string', description: 'Identifier for boot assets', value: 'org.clearlinux')
 option('with-kernel-vendor-conf-dir', type: 'string', description: 'Vendor kernel configuration directory')
 
+# Initrd options
+option('with-initrd-dir', type: 'string', description: 'Directory containing freestanding initrds')
+
 # General options
 option('with-boot-dir', type: 'string', description: 'System boot directory', value: '/boot')
 option('with-vendor-prefix', type: 'string', description: 'Prefix for files created by clr-boot-manager', value: 'generic-linux-os')

--- a/src/bootloaders/systemd-class.c
+++ b/src/bootloaders/systemd-class.c
@@ -217,6 +217,8 @@ bool sd_class_install_kernel(const BootManager *manager, const Kernel *kernel)
         const char *os_name = NULL;
         autofree(char) *old_conf = NULL;
         autofree(CbmWriter) *writer = CBM_WRITER_INIT;
+        NcHashmapIter iter = { 0 };
+        char *initrd_name = NULL;
 
         conf_path = get_entry_path_for_kernel((BootManager *)manager, kernel);
 
@@ -240,6 +242,7 @@ bool sd_class_install_kernel(const BootManager *manager, const Kernel *kernel)
                                  "linux %s/%s\n",
                                  get_kernel_destination_impl(manager),
                                  kernel->target.path);
+
         /* Optional initrd */
         if (kernel->target.initrd_path) {
                 cbm_writer_append_printf(writer,
@@ -247,6 +250,15 @@ bool sd_class_install_kernel(const BootManager *manager, const Kernel *kernel)
                                          get_kernel_destination_impl(manager),
                                          kernel->target.initrd_path);
         }
+
+        boot_manager_initrd_iterator_init(manager, &iter);
+        while (boot_manager_initrd_iterator_next(&iter, &initrd_name)) {
+                cbm_writer_append_printf(writer,
+                                         "initrd %s/%s\n",
+                                         get_kernel_destination_impl(manager),
+                                         initrd_name);
+        }
+
         /* Add the root= section */
         if (root_dev->part_uuid) {
                 cbm_writer_append_printf(writer, "options root=PARTUUID=%s ", root_dev->part_uuid);

--- a/src/bootman/bootman.h
+++ b/src/bootman/bootman.h
@@ -11,6 +11,8 @@
 
 #pragma once
 
+#include <dirent.h>
+
 #include "nica/array.h"
 #include "nica/hashmap.h"
 #include "probe.h"
@@ -350,9 +352,40 @@ static inline void kernel_array_free(void *v)
         nc_array_free(&a, (array_free_func)free_kernel);
 }
 
+/**
+ * Enumerates freestanding initrds. A "freestanding" initrd is an initrd which is
+ * not associated with a specific version of the kernel and is added to each
+ * boot configuration entry. Such initrd is expected to not contain any kernel
+ * modules. There could be any number of freestanding initrds configured.
+ * They are appended in arbitrary order after the kernel-specific initrd in the
+ * bootloader configuration file.
+ */
+bool boot_manager_enumerate_initrds_freestanding(BootManager *self);
+
+/**
+ * Copy freestanding initrd
+ */
+bool boot_manager_copy_initrd_freestanding(BootManager *self);
+
+/**
+ * Remove old freestanding initrd
+ */
+bool boot_manager_remove_initrd_freestanding(BootManager * self);
+
+/*
+ * Iterate initrd elements
+ */
+void boot_manager_initrd_iterator_init(const BootManager *manager, NcHashmapIter *iter);
+
+/**
+ * Get freestanding initrd to bootloader entry
+ */
+bool boot_manager_initrd_iterator_next(NcHashmapIter *iter, char **name);
+
 DEF_AUTOFREE(BootManager, boot_manager_free)
 DEF_AUTOFREE(KernelArray, kernel_array_free)
 DEF_AUTOFREE(Kernel, free_kernel)
+DEF_AUTOFREE(DIR, closedir)
 
 /*
  * Editor modelines  -  https://www.wireshark.org/tools/modelines.html

--- a/src/bootman/bootman_private.h
+++ b/src/bootman/bootman_private.h
@@ -25,15 +25,17 @@
 #include "os-release.h"
 
 struct BootManager {
-        char *kernel_dir;             /**<Kernel directory */
-        const BootLoader *bootloader; /**<Selected bootloader */
-        CbmOsRelease *os_release;     /**<Parsed os-release file */
-        char *abs_bootdir;            /**<Real boot dir */
-        SystemKernel sys_kernel;      /**<Native kernel info, if any */
-        bool have_sys_kernel;         /**<Whether sys_kernel is set */
-        bool image_mode;              /**<Are we in image mode? */
-        SystemConfig *sysconfig;      /**<System configuration */
-        char *cmdline;                /**<Additional cmdline to append */
+        char *kernel_dir;              /**<Kernel directory */
+        const BootLoader *bootloader;  /**<Selected bootloader */
+        CbmOsRelease *os_release;      /**<Parsed os-release file */
+        char *abs_bootdir;             /**<Real boot dir */
+        SystemKernel sys_kernel;       /**<Native kernel info, if any */
+        bool have_sys_kernel;          /**<Whether sys_kernel is set */
+        bool image_mode;               /**<Are we in image mode? */
+        SystemConfig *sysconfig;       /**<System configuration */
+        char *cmdline;                 /**<Additional cmdline to append */
+        char *initrd_freestanding_dir; /**<Initrd without kernel deps directory */
+        NcHashmap *initrd_freestanding;/**<Array of initrds without kernel deps */
 };
 
 /**

--- a/src/bootman/update.c
+++ b/src/bootman/update.c
@@ -299,6 +299,11 @@ static bool boot_manager_update_native(BootManager *self)
                 }
         }
 
+        if (!boot_manager_copy_initrd_freestanding(self)) {
+                LOG_ERROR("Failed to copying freestanding initrd");
+                return false;
+        }
+
         nc_hashmap_iter_init(mapped_kernels, &map_iter);
         while (nc_hashmap_iter_next(&map_iter, (void **)&kernel_type, (void **)&typed_kernels)) {
                 Kernel *tip = NULL;
@@ -436,7 +441,12 @@ static bool boot_manager_update_native(BootManager *self)
                         goto cleanup;
                 }
         }
+
 cleanup:
+        if (!boot_manager_remove_initrd_freestanding(self)) {
+                ret = false;
+                LOG_ERROR("Failed to remove old freestanding initrd");
+        }
         if (removals) {
                 nc_array_free(&removals, NULL);
         }

--- a/src/cli/ops/update.c
+++ b/src/cli/ops/update.c
@@ -64,6 +64,11 @@ bool cbm_command_update(int argc, char **argv)
                 }
         }
 
+        /* Grab the available freestanding initrd */
+        if (!boot_manager_enumerate_initrds_freestanding(manager)) {
+                return false;
+        }
+
         /* Let CBM take care of the rest */
         return boot_manager_update(manager);
 }

--- a/tests/check-uefi.c
+++ b/tests/check-uefi.c
@@ -387,6 +387,31 @@ START_TEST(bootman_uefi_namespace_migration)
 }
 END_TEST
 
+START_TEST(bootman_uefi_initrd_freestandings)
+{
+        autofree(BootManager) *m = NULL;
+        autofree(char) *path_initrd = NULL;
+        char *initrd_name = "00-initrd";
+
+        m = prepare_playground(&uefi_config);
+        fail_if(!m, "Failed to prepare update playground");
+
+        path_initrd = string_printf("%s%s/%s",
+                                        PLAYGROUND_ROOT,
+                                        INITRD_DIRECTORY,
+                                        initrd_name);
+
+        file_set_text(path_initrd, "Placeholder initrd");
+        /* Validate image install */
+        boot_manager_set_image_mode(m, false);
+        fail_if(!boot_manager_enumerate_initrds_freestanding(m), "Failed to find freestanding initrd");
+
+        fail_if(!check_freestanding_initrds_available(m, initrd_name), "Failed reading from initrd path");
+        fail_if(!boot_manager_update(m), "Failed to update image");
+        fail_if(!check_initrd_file_exist(m, initrd_name), "Failed copying initrd file");
+}
+END_TEST
+
 /**
  * Ensure all blobs are removed for garbage collected kernels
  */
@@ -437,6 +462,7 @@ static Suite *core_suite(void)
         tcase_add_test(tc, bootman_uefi_remove_bootloader);
         tcase_add_test(tc, bootman_uefi_namespace_migration);
         tcase_add_test(tc, bootman_uefi_ensure_removed);
+        tcase_add_test(tc, bootman_uefi_initrd_freestandings);
         suite_add_tcase(s, tc);
 
         /* Tests without kernel modules */

--- a/tests/harness.h
+++ b/tests/harness.h
@@ -114,6 +114,15 @@ void set_test_system_uefi(void);
  */
 void set_test_system_legacy(void);
 
+/**
+ * Check initrd nodeps in BootManager
+ */
+bool check_freestanding_initrds_available(BootManager *manager, const char *file_name);
+
+/**
+ * Check if initrd file exist
+ */
+bool check_initrd_file_exist(BootManager *manager, const char *file_name);
 /*
  * Editor modelines  -  https://www.wireshark.org/tools/modelines.html
  *


### PR DESCRIPTION
add suport for initrds without kernel dependencies in /usr/lib/initrd.d
just for systemd-boot at the moment

Signed-off-by: Josue David Hernandez <josue.d.hernandez.gutierrez@intel.com>