### PR TITLE
clr-boot-manager: add support for non-lvm root encryption

### DIFF
--- a/src/lib/probe.c
+++ b/src/lib/probe.c
@@ -69,10 +69,12 @@ static char *cbm_get_luks_uuid(const char *part)
         const char *value = NULL;
         const char *sys = cbm_system_get_sysfs_path();
 
-        /* i.e. /sys/block/dm-1/slaves/dm-0/slaves/sdb1/dev */
-        npath = string_printf("%s/block/%s/slaves/*/slaves/*/dev", sys, part);
+        /* i.e. /sys/block/dm-1/slaves/dm-0/slaves/sdb1/dev
+         * or /sys/block/dm-1/slaves/sdb1/dev
+         */
+        npath = string_printf("%s/block/%s/slaves/*{,/slaves/*}/dev", sys, part);
 
-        glob(npath, GLOB_DOOFFS, NULL, &glo);
+        glob(npath, GLOB_DOOFFS | GLOB_BRACE, NULL, &glo);
 
         if (glo.gl_pathc < 1) {
                 globfree(&glo);


### PR DESCRIPTION
Signed-off-by: Josue David Hernandez <josue.d.hernandez.gutierrez@intel.com>