### PR TITLE
clr-boot-manager: add rd.luks.options=timeout=90

### DIFF
--- a/src/bootloaders/grub2.c
+++ b/src/bootloaders/grub2.c
@@ -239,6 +239,7 @@ bool grub2_write_kernel(const Grub2Config *config, const Kernel *kernel)
                 cbm_writer_append_printf(config->writer,
                                          "rd.luks.uuid=%s ",
                                          config->root_dev->luks_uuid);
+                cbm_writer_append_printf(config->writer, "rd.luks.options=timeout=90 ");
         }
 
         /* Finish it off with the command line options */

--- a/src/bootloaders/syslinux.c
+++ b/src/bootloaders/syslinux.c
@@ -176,6 +176,7 @@ static bool syslinux_set_default_kernel(const BootManager *manager, const Kernel
                 /* Add LUKS information if relevant */
                 if (root_dev->luks_uuid) {
                         cbm_writer_append_printf(writer, "rd.luks.uuid=%s ", root_dev->luks_uuid);
+                        cbm_writer_append_printf(writer, "rd.luks.options=timeout=90 ");
                 }
 
                 /* Write out the cmdline */

--- a/src/bootloaders/systemd-class.c
+++ b/src/bootloaders/systemd-class.c
@@ -268,6 +268,7 @@ bool sd_class_install_kernel(const BootManager *manager, const Kernel *kernel)
         /* Add LUKS information if relevant */
         if (root_dev->luks_uuid) {
                 cbm_writer_append_printf(writer, "rd.luks.uuid=%s ", root_dev->luks_uuid);
+                cbm_writer_append_printf(writer, "rd.luks.options=timeout=90 ");
         }
 
         /* Finish it off with the command line options */


### PR DESCRIPTION
some legacy systemd versions don't take rd.luks.options=timeout=0 (default)
as unlimited, it means there is not time to provide the password for an
encrypted device

Signed-off-by: Josue David Hernandez <josue.d.hernandez.gutierrez@intel.com>