### PR TITLE
Increase maximum size of 'type' field

### DIFF
--- a/src/bootman/kernel.c
+++ b/src/bootman/kernel.c
@@ -46,7 +46,7 @@ Kernel *boot_manager_inspect_kernel(BootManager *self, char *path)
 {
         Kernel *kern = NULL;
         autofree(char) *cmp = NULL;
-        char type[15] = { 0 };
+        char type[32] = { 0 };
         char version[15] = { 0 };
         int release = 0;
         autofree(char) *parent = NULL;
@@ -72,7 +72,7 @@ Kernel *boot_manager_inspect_kernel(BootManager *self, char *path)
         bcp = basename(cmp);
 
         /* org.clearlinux.kvm.4.2.1-121 */
-        r = sscanf(bcp, KERNEL_NAMESPACE ".%15[^.].%15[^-]-%d", type, version, &release);
+        r = sscanf(bcp, KERNEL_NAMESPACE ".%32[^.].%15[^-]-%d", type, version, &release);
         if (r != 3) {
                 return NULL;
         }


### PR DESCRIPTION
In practice, the filename limit was overly small, this change allows
us to better describe the content of some kernels currently in use.

Signed-off-by: Murilo Belluzzo <murilo.belluzzo@intel.com>