### PR TITLE
Enable commandline removal configuration files

### DIFF
--- a/man/clr-boot-manager.1.in
+++ b/man/clr-boot-manager.1.in
@@ -105,6 +105,16 @@ can also be used to mask the vendor cmdline if the filename matches a vendor
 configuration file and is linked to /dev/null\&.
 .RE
 
+.PP
+\fB@KERNEL_CONF_DIRECTORY@/cmdline-removal.d/*.conf\fR
+.RS 4
+A set of files that will be used to modify the kernel commandline by removing
+string matches from the final consolidated commandline (removal happens after
+the content from cmdline and cmdline.d/*.conf files are added). The matches
+are made on a per line basis so multiple different removals should be placed
+on their own line or file\&.
+.RE
+
 
 .SH "ENVIRONMENT"
 \fI$CBM_DEBUG\fR

--- a/src/lib/cmdline.c
+++ b/src/lib/cmdline.c
@@ -79,7 +79,7 @@ static int cbm_parse_cmdline_file_internal(const char *path, FILE *out)
                 r -= cur;
 
                 /* Strip trailing whitespace */
-                l = rstrip(l, (size_t)r, &r);
+                l = rstrip(l, (size_t *)&r);
 
                 /* May now be an empty line */
                 if (r < 1) {

--- a/src/lib/os-release.c
+++ b/src/lib/os-release.c
@@ -113,7 +113,7 @@ static bool cbm_os_release_parse(CbmOsRelease *self, const char *path)
                 r -= cur;
 
                 /* Strip trailing whitespace */
-                l = rstrip(l, (size_t)r, &r);
+                l = rstrip(l, (size_t *)&r);
 
                 /* May now be an empty line */
                 if (r < 1) {

--- a/src/lib/util.c
+++ b/src/lib/util.c
@@ -16,24 +16,30 @@
 
 #include "util.h"
 
-char *rstrip(char *a, size_t len, ssize_t *newlen)
+char *rstrip(char *a, size_t *len)
 {
-        char *e = a + len - 1;
-        if (len < 1) {
+        /* start at the last character in the string */
+        char *e = a + *len - 1;
+
+        if (*len < 1) {
                 return a;
         }
 
         for (;;) {
-                if (!isspace(*e) || e <= a) {
+                if (e < a || !isspace(*e)) {
                         break;
                 }
                 --e;
         }
-        if (newlen) {
-                *newlen = e - a + 1;
+
+        if (e < a) {
+                *len = 0;
+                *a = '\0';
+        } else {
+                *len = (size_t)(e - a) + 1;
+                *(e + 1) = '\0';
         }
 
-        *(e + 1) = '\0';
         return a;
 }
 

--- a/src/lib/util.h
+++ b/src/lib/util.h
@@ -55,7 +55,7 @@
  * Strip the right side of a string of it's whitespace
  * This must be allocated memory
  */
-char *rstrip(char *a, size_t len, ssize_t *newlen);
+char *rstrip(char *a, size_t *len);
 
 /**
  * Similar to asprintf, but will assert allocation of the string.

--- a/tests/check-cmdline.c
+++ b/tests/check-cmdline.c
@@ -105,6 +105,42 @@ START_TEST(cbm_cmdline_test_dirs_vendor_merged)
 }
 END_TEST
 
+START_TEST(cbm_cmdline_test_delete_middle)
+{
+        const char *dir = TOP_DIR "/tests/data/cmdline_delete_middle";
+
+        autofree(char) *p = NULL;
+
+        p = cbm_parse_cmdline_files(dir);
+        fail_if(!p, "Failed to parse cmdline file");
+        fail_if(!streq(p, "pre post"), "Delete middle file does not match");
+}
+END_TEST
+
+START_TEST(cbm_cmdline_test_delete_ends)
+{
+        const char *dir = TOP_DIR "/tests/data/cmdline_delete_ends";
+
+        autofree(char) *p = NULL;
+
+        p = cbm_parse_cmdline_files(dir);
+        fail_if(!p, "Failed to parse cmdline file");
+        fail_if(!streq(p, "two three "), "Delete ends does not match");
+}
+END_TEST
+
+START_TEST(cbm_cmdline_test_delete_all)
+{
+        const char *dir = TOP_DIR "/tests/data/cmdline_delete_all";
+
+        autofree(char) *p = NULL;
+
+        p = cbm_parse_cmdline_files(dir);
+        fail_if(!p, "Failed to parse cmdline file");
+        fail_if(!streq(p, ""), "Delete all cmdline does not match");
+}
+END_TEST
+
 static Suite *core_suite(void)
 {
         Suite *s = NULL;
@@ -119,6 +155,9 @@ static Suite *core_suite(void)
         tcase_add_test(tc, cbm_cmdline_test_dirs);
         tcase_add_test(tc, cbm_cmdline_test_dirs_vendor_only);
         tcase_add_test(tc, cbm_cmdline_test_dirs_vendor_merged);
+        tcase_add_test(tc, cbm_cmdline_test_delete_middle);
+        tcase_add_test(tc, cbm_cmdline_test_delete_ends);
+        tcase_add_test(tc, cbm_cmdline_test_delete_all);
         suite_add_tcase(s, tc);
 
         return s;

--- a/tests/data/cmdline_delete_all/etc/kernel/cmdline-removal.d/comments.conf
+++ b/tests/data/cmdline_delete_all/etc/kernel/cmdline-removal.d/comments.conf
@@ -1,0 +1,3 @@
+# This file
+init=/bin/bash
+  # has comments!

--- a/tests/data/cmdline_delete_all/etc/kernel/cmdline-removal.d/mangledmess.conf
+++ b/tests/data/cmdline_delete_all/etc/kernel/cmdline-removal.d/mangledmess.conf
@@ -1,0 +1,5 @@
+    foobar
+# Some things may
+            rw
+   # Follow!
+i8042.nomux thing=off

--- a/tests/data/cmdline_delete_all/etc/kernel/cmdline-removal.d/multi.conf
+++ b/tests/data/cmdline_delete_all/etc/kernel/cmdline-removal.d/multi.conf
@@ -1,0 +1,3 @@
+one
+two
+three

--- a/tests/data/cmdline_delete_all/etc/kernel/cmdline-removal.d/oneline.conf
+++ b/tests/data/cmdline_delete_all/etc/kernel/cmdline-removal.d/oneline.conf
@@ -1,0 +1,1 @@
+a single line command line file

--- a/tests/data/cmdline_delete_all/usr/share/kernel/cmdline.d/full.conf
+++ b/tests/data/cmdline_delete_all/usr/share/kernel/cmdline.d/full.conf
@@ -1,0 +1,1 @@
+init=/bin/bash foobar rw i8042.nomux thing=off one two three a single line command line file

--- a/tests/data/cmdline_delete_ends/etc/kernel/cmdline-removal.d/ends.conf
+++ b/tests/data/cmdline_delete_ends/etc/kernel/cmdline-removal.d/ends.conf
@@ -1,0 +1,2 @@
+one
+four

--- a/tests/data/cmdline_delete_ends/usr/share/kernel/cmdline.d/full.conf
+++ b/tests/data/cmdline_delete_ends/usr/share/kernel/cmdline.d/full.conf
@@ -1,0 +1,1 @@
+one two three four

--- a/tests/data/cmdline_delete_middle/etc/kernel/cmdline-removal.d/comments.conf
+++ b/tests/data/cmdline_delete_middle/etc/kernel/cmdline-removal.d/comments.conf
@@ -1,0 +1,3 @@
+# This file
+init=/bin/bash
+  # has comments!

--- a/tests/data/cmdline_delete_middle/etc/kernel/cmdline-removal.d/mangledmess.conf
+++ b/tests/data/cmdline_delete_middle/etc/kernel/cmdline-removal.d/mangledmess.conf
@@ -1,0 +1,5 @@
+    foobar
+# Some things may
+            rw
+   # Follow!
+i8042.nomux thing=off

--- a/tests/data/cmdline_delete_middle/etc/kernel/cmdline-removal.d/multi.conf
+++ b/tests/data/cmdline_delete_middle/etc/kernel/cmdline-removal.d/multi.conf
@@ -1,0 +1,3 @@
+one
+two
+three

--- a/tests/data/cmdline_delete_middle/etc/kernel/cmdline-removal.d/oneline.conf
+++ b/tests/data/cmdline_delete_middle/etc/kernel/cmdline-removal.d/oneline.conf
@@ -1,0 +1,1 @@
+a single line command line file

--- a/tests/data/cmdline_delete_middle/usr/share/kernel/cmdline.d/full.conf
+++ b/tests/data/cmdline_delete_middle/usr/share/kernel/cmdline.d/full.conf
@@ -1,0 +1,1 @@
+pre init=/bin/bash foobar rw i8042.nomux thing=off one two three a single line command line file post


### PR DESCRIPTION
Add the ability for clr-boot-manager to handle removing content from
the kernel commandline. The removal configuration files are formatted
exactly the same as the add configuration files. The matches are done
line-by-line so that:

"option-a option-b"

in a removal file would only delete exactly that string unlike:
"option-a
option-b"

in a removal file which would try to remove "option-a" and "option-b"
separately.