### PR TITLE
Let's use https for security reasons

### DIFF
--- a/man/clr-boot-manager.1.in
+++ b/man/clr-boot-manager.1.in
@@ -168,5 +168,5 @@ Attribution\-ShareAlike 3.0 Unported\s-2\u[1]\d\s+2\&.
 .IP " 1." 4
 Creative Commons Attribution\-ShareAlike 3.0 Unported
 .RS 4
-\%http://creativecommons.org/licenses/by-sa/3.0/
+\%https://creativecommons.org/licenses/by-sa/3.0/
 .RE


### PR DESCRIPTION
This is nothing major, but I saw that the link inside the man page was using unencrypted http so I figured I would send a little PR to fix it. With all the talk about security online and stuff we should try to use https as much as possible. :)