### PR TITLE
Fix: kernel release version support bigger number

### DIFF
--- a/src/bootman/kernel.c
+++ b/src/bootman/kernel.c
@@ -213,7 +213,7 @@ Kernel *boot_manager_inspect_kernel(BootManager *self, char *path)
                     string_printf("initrd-%s.%s.%s-%d", KERNEL_NAMESPACE, type, version, release);
         }
 
-        kern->meta.release = (int16_t)release;
+        kern->meta.release = (int)release;
 
         /* cmdline */
         kern->meta.cmdline = cbm_parse_cmdline_file(cmdline);


### PR DESCRIPTION
Fix issue log:
https://github.com/clearlinux/clr-boot-manager/issues/137