### PR TITLE
Fix output of DECLARE_OOM macro

### DIFF
--- a/src/lib/util.h
+++ b/src/lib/util.h
@@ -21,7 +21,7 @@
 #include <string.h>
 #include <sys/types.h>
 
-#define DECLARE_OOM() (fputs("Out of memory", stderr))
+#define DECLARE_OOM() (fputs("Out of memory\n", stderr))
 
 #define OOM_CHECK(x)                                                                               \
         {                                                                                          \


### PR DESCRIPTION
The DECLARE_OOM macro didn't add a newline at the end leading to
potentially confusing output.