### PR TITLE
Do not attempt an update without a kernel dir

### DIFF
--- a/src/bootman/bootman.h
+++ b/src/bootman/bootman.h
@@ -210,6 +210,16 @@ const char *boot_manager_get_os_id(BootManager *self);
 KernelArray *boot_manager_get_kernels(BootManager *manager);
 
 /**
+ * Detect potential kernel availability, returning a bool based on results
+ *
+ * @note Looks for kernel directory rather than kernel files
+ *
+ * @param path Path to use as prefix
+ * @return a bool indicating if the kernel directory exists
+ */
+bool boot_manager_detect_kernel_dir(char *path);
+
+/**
  * Inspect a kernel file, returning a machine-usable description
  *
  * @note free the returned struct with free_kernel

--- a/src/bootman/kernel.c
+++ b/src/bootman/kernel.c
@@ -42,6 +42,19 @@ __cbm_inline__ static inline char *boot_manager_get_kboot_file(BootManager *self
         return p;
 }
 
+bool boot_manager_detect_kernel_dir(char *path)
+{
+        autofree(char) *kernel_dir = NULL;
+
+        kernel_dir = path ? string_printf("%s/%s", path, KERNEL_DIRECTORY) :
+                string_printf("/%s", KERNEL_DIRECTORY);
+        if (!nc_file_exists(kernel_dir)) {
+                return false;
+        }
+
+        return true;
+}
+
 Kernel *boot_manager_inspect_kernel(BootManager *self, char *path)
 {
         Kernel *kern = NULL;

--- a/src/cli/ops/update.c
+++ b/src/cli/ops/update.c
@@ -37,6 +37,10 @@ bool cbm_command_update(int argc, char **argv)
                 return false;
         }
 
+        if (!boot_manager_detect_kernel_dir(root)) {
+                fprintf(stderr, "No kernels detected on system to update\n");
+                return true;
+        }
         if (root) {
                 autofree(char) *realp = NULL;
 
@@ -63,10 +67,6 @@ bool cbm_command_update(int argc, char **argv)
                 if (!boot_manager_set_prefix(manager, "/")) {
                         return false;
                 }
-        }
-        if (!nc_file_exists(boot_manager_get_kernel_dir(manager))) {
-                LOG_INFO("No kernels to process, exiting");
-                return true;
         }
         /* Grab the available freestanding initrd */
         if (!boot_manager_enumerate_initrds_freestanding(manager)) {


### PR DESCRIPTION
Previous code would try and find informatin about the given root even
when the kernel dir under the root did not exist causing unhelpful
errors. Update to check if the kernel dir exists before probing the
given root and exit if it does not.