### PR TITLE
completions: Minor fix on comments

### DIFF
--- a/data/completions/bash/clr-boot-manager.in
+++ b/data/completions/bash/clr-boot-manager.in
@@ -1,6 +1,6 @@
 #!/bin/bash
 # -----------------------------------------------------------------------
-#   Software Updater - autocompletion script
+#   Kernel & Boot Loader Management - autocompletion script
 #
 #   Author: Lucius Hu - http://github.com/lebensterben
 #

--- a/data/completions/zsh/_clr-boot-manager.in
+++ b/data/completions/zsh/_clr-boot-manager.in
@@ -1,6 +1,6 @@
 #compdef clr-boot-manager
 # -----------------------------------------------------------------------
-#   Software Updater - autocompletion script
+#   Kernel & Boot Loader Management - autocompletion script
 #
 #   Author: Lucius Hu - http://github.com/lebensterben
 #


### PR DESCRIPTION
It was wrongly described as `Software Updater - autocompletion script`, and it's changed to
`Kernel & Boot Loader Management - autocompletion script`.