### PR TITLE
bootman: avoid a buffer overflow

### DIFF
--- a/src/bootman/kernel.c
+++ b/src/bootman/kernel.c
@@ -464,7 +464,7 @@ bool cbm_parse_system_kernel(const char *inp, SystemKernel *kernel)
                 ++len;
         }
 
-        if (len < 1 || len > CBM_KELEM_LEN) {
+        if (len < 1 || len + 1 > CBM_KELEM_LEN) {
                 return false;
         }
 


### PR DESCRIPTION
On the cbm_parse_system_kernel() we're not leaving room for \0 by
checking only "len" and not considering the end line terminator.

Thanks @anselmolsm for spotting that one.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>