### PR TITLE
efi: add a entry_label argument

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -153,6 +153,12 @@ if with_systemd_system_unit_dir == ''
     endif
 endif
 
+# Vendor configuration
+with_uefi_entry_label = get_option('with-uefi-entry-label')
+if with_uefi_entry_label == ''
+   with_uefi_entry_label = 'Linux bootloader'
+endif
+
 # Set config.h options up for our general directories, etc.
 cdata.set_quoted('KERNEL_DIRECTORY', with_kernel_dir)
 cdata.set_quoted('INITRD_DIRECTORY', with_initrd_dir)
@@ -162,6 +168,7 @@ cdata.set_quoted('BOOT_DIRECTORY', with_boot_dir)
 cdata.set_quoted('VENDOR_PREFIX', with_vendor_prefix)
 cdata.set_quoted('KERNEL_CONF_DIRECTORY', with_kernel_conf_dir)
 cdata.set_quoted('VENDOR_KERNEL_CONF_DIRECTORY', with_kernel_vendor_conf_dir)
+cdata.set_quoted('UEFI_ENTRY_LABEL', with_uefi_entry_label)
 
 # Helps the test suites
 test_top_dir = meson.current_source_dir()
@@ -194,6 +201,7 @@ report = [
     '    datadir:                                @0@'.format(path_datadir),
     '    sysconfdir:                             @0@'.format(path_sysconfdir),
     '    systemd unit directory:                 @0@'.format(with_systemd_system_unit_dir),
+    '    uefi entry label:                       @0@'.format(with_uefi_entry_label),
     '',
     '    Identification:',
     '    ===============',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -24,3 +24,4 @@ option('bash_completions', type: 'boolean', value: true, description: 'Install b
 option('zsh_completions', type: 'boolean', value: true, description: 'Install zsh shell completions.')
 option('with-bash-completions-dir', type: 'string', description: 'System bash completions directory')
 option('with-zsh-completions-dir', type: 'string', description: 'System zsh completions directory')
+option('with-uefi-entry-label', type: 'string', description: 'uefi entry label')

--- a/src/lib/bootvar.c
+++ b/src/lib/bootvar.c
@@ -23,6 +23,7 @@
 #include <alloca.h>
 #include <blkid.h>
 #include <ctype.h>
+#include <config.h>
 #include <efi.h>
 #include <efiboot.h>
 #include <efilib.h>
@@ -418,7 +419,7 @@ static int bootvar_make_boot_rec_data(const char *esp_mount_path, const char *bo
                                  LOAD_OPTION_ACTIVE,
                                  (void *)fdev_path,
                                  len,
-                                 (unsigned char *)"Linux bootloader",
+                                 (unsigned char *)UEFI_ENTRY_LABEL,
                                  NULL,
                                  0);
         if (len < 0) {


### PR DESCRIPTION
With that each vendor can create a more meaningful uefi menu entry if provided on
build time.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>