### PR TITLE
Help: add a generic way of dealing with default opts

### DIFF
--- a/src/cli/cli.c
+++ b/src/cli/cli.c
@@ -18,15 +18,46 @@
 
 #include "cli.h"
 
-static struct option default_opts[] = { { "path", required_argument, 0, 'p' },
-                                        { "image", no_argument, 0, 'i' },
-                                        { 0, 0, 0, 0 } };
+struct cli_option {
+        struct option opt;
+        char *desc;
+};
+
+#define OPTION(opt, req, flag, short_opt, desc)       \
+        { {opt, req, flag, short_opt}, desc }         \
+
+static struct cli_option cli_opts[] = {
+        OPTION("path", required_argument, 0, 'p', "Set the base path for boot management operations."),
+        OPTION("image", no_argument, 0, 'i', "Force clr-boot-manager to run in image mode."),
+        OPTION(0, 0, 0, 0, NULL),
+};
+
+void cli_print_default_args_help(void)
+{
+        int opt_len = (sizeof(cli_opts) / sizeof(struct cli_option)) - 1;
+
+        fprintf(stdout, "\nOptions:\n");
+
+        for (int i = 0; i < opt_len; i++) {
+                struct cli_option curr = cli_opts[i];
+                fprintf(stdout, "  -%c, --%s\t%s\n", curr.opt.val,
+                        curr.opt.name, curr.desc);
+        }
+}
 
 bool cli_default_args_init(int *argc, char ***argv, char **root, bool *forced_image)
 {
         int o_in = 0;
         int c;
         char *_root = NULL;
+        int opt_len = sizeof(cli_opts) / sizeof(struct cli_option);
+        struct option *default_opts;
+
+        default_opts = alloca(sizeof(struct option) * (long unsigned int)opt_len);
+
+        for (int i = 0; i < opt_len; i++) {
+                default_opts[i] = cli_opts[i].opt;
+        }
 
         /* We actually want to use getopt, so rewind one for getopt */;
         --(*argv);

--- a/src/cli/cli.h
+++ b/src/cli/cli.h
@@ -25,6 +25,7 @@ typedef struct SubCommand {
 } SubCommand;
 
 bool cli_default_args_init(int *argc, char ***argv, char **root, bool *forced_image);
+void cli_print_default_args_help(void);
 
 /*
  * Editor modelines  -  https://www.wireshark.org/tools/modelines.html

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -44,10 +44,7 @@ static bool print_usage(int argc, char **argv)
         const char *id = NULL;
         const SubCommand *command = NULL;
 
-        if (argc > 1) {
-                fprintf(stderr, "Usage: %s help [topic]\n", binary_name);
-                return false;
-        } else if (argc == 1 && !explicit_help) {
+        if (argc >= 1 && !explicit_help) {
                 command = nc_hashmap_get(g_commands, argv[0]);
                 if (!command) {
                         fprintf(stderr, "Unknown topic '%s'\n", argv[0]);

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -56,6 +56,11 @@ static bool print_usage(int argc, char **argv)
                         command->name,
                         command->usage ? command->usage : "");
                 fprintf(stdout, "\n%s\n", command->help ? command->help : command->blurb);
+
+                if (!streq(argv[0], "help") && !streq(argv[0], "version")) {
+                        cli_print_default_args_help();
+                }
+
                 return true;
         }
 
@@ -65,6 +70,8 @@ static bool print_usage(int argc, char **argv)
         while (nc_hashmap_iter_next(&iter, (void **)&id, (void **)&command)) {
                 fprintf(stdout, "%15s - %s\n", id, command->blurb);
         }
+
+        cli_print_default_args_help();
 
         return true;
 }


### PR DESCRIPTION
A few house keeping on the clr-boot-manager's cli.

* Remove dead code
* added common code to deal with default opts and showing'em on the help display in a generic way;