### PR TITLE
man: add /etc/kernel/initrd.d documentation

### DIFF
--- a/man/clr-boot-manager.1.in
+++ b/man/clr-boot-manager.1.in
@@ -151,6 +151,16 @@ be applied every time clr-boot-manager is called - even when called by a externa
 tool non interactively. Possible values are: \fBno\fR, \fBfalse\fR\&.
 .RE
 
+.PP
+\fB@KERNEL_CONF_DIRECTORY@/initrd.d/*\fR
+.RS 4
+A set of files that will be used as additional user's freestanding initrd files.
+Additional initrd arguments will be added to the kernel argument list, if desired
+the user may mask out system installed initrd files by creating symbolic links
+within \fB@KERNEL_CONF_DIRECTORY@/initrd.d\fR pointing to \fB/dev/null\fR with same
+name of system installed files.
+.RE
+
 .SH "ENVIRONMENT"
 \fI$CBM_DEBUG\fR
 .RS 4


### PR DESCRIPTION
We're missing man page documentation to the recent user initrd freestanding
file.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>