### PR TITLE
grub2: make it optional

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -177,6 +177,11 @@ cdata.set_quoted('KERNEL_CONF_DIRECTORY', with_kernel_conf_dir)
 cdata.set_quoted('VENDOR_KERNEL_CONF_DIRECTORY', with_kernel_vendor_conf_dir)
 cdata.set_quoted('UEFI_ENTRY_LABEL', with_uefi_entry_label)
 
+with_grub2_backend = get_option('with-grub2-backend')
+if with_grub2_backend == true
+   cdata.set('GRUB2_BACKEND_ENABLED', with_grub2_backend)
+endif
+
 # Helps the test suites
 test_top_dir = meson.current_source_dir()
 
@@ -230,6 +235,7 @@ report = [
     '',
     '    bootloader:                             @0@'.format(with_bootloader),
     '    efi variable support:                   @0@'.format(require_efi),
+    '    grub backend:                           @0@'.format(with_grub2_backend),
 ]
 
 # Output some stuff to validate the build config

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,6 +1,8 @@
 # Bootloader to use
 option('with-bootloader', type: 'combo', choices:
     ['systemd-boot', 'shim-systemd-boot'], value: 'shim-systemd-boot')
+option('with-grub2-backend', type: 'boolean', value: true,
+    description: 'Enables grub2 backend support.')
 
 # Currently we'll only look for gnu-efi when using shim-systemd-boot
 option('with-gnu-efi', type: 'string', description: 'Location of the gnu-efi headers')

--- a/src/bootman/bootman.c
+++ b/src/bootman/bootman.c
@@ -33,7 +33,10 @@
 /**
  * Total "usable" bootloaders
  */
+#if defined(GRUB2_BACKEND_ENABLED)
 extern const BootLoader grub2_bootloader;
+#endif
+
 #if defined(HAVE_SHIM_SYSTEMD_BOOT)
 extern const BootLoader shim_systemd_bootloader;
 #endif
@@ -56,7 +59,9 @@ const BootLoader *bootman_known_loaders[] =
 #elif defined(HAVE_SYSTEMD_BOOT)
       &systemd_bootloader,
 #endif
+#if defined(GRUB2_BACKEND_ENABLED)
       &grub2_bootloader, /**<Always place first to allow extlinux to override */
+#endif
       /* non-systemd-class */
       &syslinux_bootloader,
       &extlinux_bootloader};

--- a/src/meson.build
+++ b/src/meson.build
@@ -33,7 +33,6 @@ link_libnica = declare_dependency(
 libcbm_sources = [
     'bootloaders/systemd-class.c',
     'bootloaders/systemd-boot.c',
-    'bootloaders/grub2.c',
     'bootloaders/extlinux.c',
     'bootloaders/syslinux.c',
     'bootloaders/mbr.c',
@@ -52,6 +51,12 @@ libcbm_sources = [
     'lib/writer.c',
     'lib/util.c',
 ]
+
+if with_grub2_backend == true
+libcbm_sources += [
+    'bootloaders/grub2.c',
+]
+endif
 
 libcbm_includes = [
     include_directories('bootloaders'),


### PR DESCRIPTION
We would like to disable grub2 in scenarios/configurations where we
know we won't ever use/need it.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>