### PR TITLE
image mode: unify image mode and native mode

### DIFF
--- a/man/clr-boot-manager.1.in
+++ b/man/clr-boot-manager.1.in
@@ -37,7 +37,7 @@ Set the base path for boot management operations\&.
 .PP
 \fB\-i\fR, \fB\-\-image\fR
 .RS 4
-Force \fBclr\-boot\-manager\fR to run in image mode\&.
+Force \fBclr\-boot\-manager\fR to run in image mode(deprecated)\&.
 .RE
 .PP
 \fB\-n\fR, \fB\-\-no-efi-update\fR

--- a/src/bootman/bootman.c
+++ b/src/bootman/bootman.c
@@ -92,9 +92,6 @@ BootManager *boot_manager_new()
                 }
         }
 
-        /* CLI can override this */
-        boot_manager_set_image_mode(r, false);
-
         r->initrd_freestanding = nc_hashmap_new_full(nc_string_hash,
                                                      nc_string_compare, free, free_initrd_entry);
         OOM_CHECK(r->initrd_freestanding);
@@ -181,7 +178,7 @@ bool boot_manager_set_prefix(BootManager *self, char *prefix)
         cbm_free_sysconfig(self->sysconfig);
         self->sysconfig = NULL;
 
-        config = cbm_inspect_root(prefix, self->image_mode);
+        config = cbm_inspect_root(prefix);
         CHECK_DBG_RET_VAL(!config, false, "Could not inspect root");
 
         self->sysconfig = config;
@@ -687,20 +684,6 @@ bool boot_manager_modify_bootloader(BootManager *self, int flags)
                 LOG_FATAL("Unknown bootloader operation");
                 return false;
         }
-}
-
-bool boot_manager_is_image_mode(BootManager *self)
-{
-        assert(self != NULL);
-
-        return self->image_mode;
-}
-
-void boot_manager_set_image_mode(BootManager *self, bool image_mode)
-{
-        assert(self != NULL);
-
-        self->image_mode = image_mode;
 }
 
 bool boot_manager_needs_install(BootManager *self)

--- a/src/bootman/bootman.h
+++ b/src/bootman/bootman.h
@@ -291,17 +291,6 @@ const CbmDeviceProbe *boot_manager_get_root_device(BootManager *manager);
 bool boot_manager_modify_bootloader(BootManager *manager, int ops);
 
 /**
- * Determine if the BootManager is operating in image mode, i.e.
- * the prefix/root is not "/" - the native filesystem
- */
-bool boot_manager_is_image_mode(BootManager *manager);
-
-/**
- * Flip the boot manager into image mode
- */
-void boot_manager_set_image_mode(BootManager *manager, bool image_mode);
-
-/**
  * Set boot manager flag, determining if it should or not update efi variables
  */
 void boot_manager_set_update_efi_vars(BootManager *self, bool update_efi_vars);
@@ -384,7 +373,7 @@ void cbm_free_sysconfig(SystemConfig *config);
 /**
  * Inspect a given root path and return a new SystemConfig for it
  */
-SystemConfig *cbm_inspect_root(const char *path, bool image_mode);
+SystemConfig *cbm_inspect_root(const char *path);
 
 /**
  * Determine if the given SystemConfig is sane for use

--- a/src/bootman/bootman_private.h
+++ b/src/bootman/bootman_private.h
@@ -31,7 +31,6 @@ struct BootManager {
         char *abs_bootdir;             /**<Real boot dir */
         SystemKernel sys_kernel;       /**<Native kernel info, if any */
         bool have_sys_kernel;          /**<Whether sys_kernel is set */
-        bool image_mode;               /**<Are we in image mode? */
         bool update_efi_vars;          /**<Should we update efi variables? */
         SystemConfig *sysconfig;       /**<System configuration */
         char *cmdline;                 /**<Additional cmdline to append */

--- a/src/bootman/kernel.c
+++ b/src/bootman/kernel.c
@@ -478,9 +478,6 @@ const SystemKernel *boot_manager_get_system_kernel(BootManager *self)
         if (!self || !self->have_sys_kernel) {
                 return NULL;
         }
-        if (boot_manager_is_image_mode(self)) {
-                return NULL;
-        }
         return (const SystemKernel *)&(self->sys_kernel);
 }
 

--- a/src/cli/cli.c
+++ b/src/cli/cli.c
@@ -32,7 +32,7 @@ struct cli_option {
 
 static struct cli_option cli_opts[] = {
         OPTION("path", required_argument, 0, 'p', "Set the base path for boot management operations."),
-        OPTION("image", no_argument, 0, 'i', "Force clr-boot-manager to run in image mode."),
+        OPTION("image", no_argument, 0, 'i', "Force clr-boot-manager to run in image mode(deprecated)."),
         OPTION("no-efi-update", no_argument, 0, 'n',
                "Don't update efi vars when using shim-systemd backend."),
         OPTION(0, 0, 0, 0, NULL),
@@ -67,8 +67,7 @@ void cli_print_default_args_help(void)
         }
 }
 
-bool cli_default_args_init(int *argc, char ***argv, char **root, bool *forced_image,
-                           bool *update_efi_vars)
+bool cli_default_args_init(int *argc, char ***argv, char **root, bool *update_efi_vars)
 {
         int o_in = 0;
         int c;
@@ -108,9 +107,7 @@ bool cli_default_args_init(int *argc, char ***argv, char **root, bool *forced_im
                         }
                         break;
                 case 'i':
-                        if (forced_image) {
-                                *forced_image = true;
-                        }
+                        LOG_INFO("-i,--image flags are deprecated");
                         break;
                 case 'n':
                         if (update_efi_vars) {

--- a/src/cli/cli.h
+++ b/src/cli/cli.h
@@ -24,8 +24,7 @@ typedef struct SubCommand {
         bool requires_root;
 } SubCommand;
 
-bool cli_default_args_init(int *argc, char ***argv, char **root, bool *forced_image,
-                           bool *update_efi_vars);
+bool cli_default_args_init(int *argc, char ***argv, char **root, bool *update_efi_vars);
 void cli_print_default_args_help(void);
 
 /*

--- a/src/cli/ops/kernels.c
+++ b/src/cli/ops/kernels.c
@@ -25,11 +25,10 @@ bool cbm_command_list_kernels(int argc, char **argv)
 {
         autofree(char) *root = NULL;
         autofree(BootManager) *manager = NULL;
-        bool forced_image = false;
         char **kernels = NULL;
         bool update_efi_vars = true;
 
-        if (!cli_default_args_init(&argc, &argv, &root, &forced_image, &update_efi_vars)) {
+        if (!cli_default_args_init(&argc, &argv, &root, &update_efi_vars)) {
                 return false;
         }
 
@@ -42,27 +41,10 @@ bool cbm_command_list_kernels(int argc, char **argv)
         boot_manager_set_update_efi_vars(manager, update_efi_vars);
 
         if (root) {
-                autofree(char) *realp = NULL;
-
-                realp = realpath(root, NULL);
-                if (!realp) {
-                        LOG_FATAL("Path specified does not exist: %s", root);
-                        return false;
-                }
-                /* Anything not / is image mode */
-                if (!streq(realp, "/")) {
-                        boot_manager_set_image_mode(manager, true);
-                } else {
-                        boot_manager_set_image_mode(manager, forced_image);
-                }
-
-                /* CBM will check this again, we just needed to check for
-                 * image mode.. */
                 if (!boot_manager_set_prefix(manager, root)) {
                         return false;
                 }
         } else {
-                boot_manager_set_image_mode(manager, forced_image);
                 /* Default to "/", bail if it doesn't work. */
                 if (!boot_manager_set_prefix(manager, "/")) {
                         return false;
@@ -86,14 +68,13 @@ bool cbm_command_set_kernel(int argc, char **argv)
 {
         autofree(char) *root = NULL;
         autofree(BootManager) *manager = NULL;
-        bool forced_image = false;
         char type[32] = { 0 };
         char version[16] = { 0 };
         int release = 0;
         Kernel kern = { 0 };
         bool update_efi_vars = true;
 
-        if (!cli_default_args_init(&argc, &argv, &root, &forced_image, &update_efi_vars)) {
+        if (!cli_default_args_init(&argc, &argv, &root, &update_efi_vars)) {
                 return false;
         }
 
@@ -106,27 +87,10 @@ bool cbm_command_set_kernel(int argc, char **argv)
         boot_manager_set_update_efi_vars(manager, update_efi_vars);
 
         if (root) {
-                autofree(char) *realp = NULL;
-
-                realp = realpath(root, NULL);
-                if (!realp) {
-                        LOG_FATAL("Path specified does not exist: %s", root);
-                        return false;
-                }
-                /* Anything not / is image mode */
-                if (!streq(realp, "/")) {
-                        boot_manager_set_image_mode(manager, true);
-                } else {
-                        boot_manager_set_image_mode(manager, forced_image);
-                }
-
-                /* CBM will check this again, we just needed to check for
-                 * image mode.. */
                 if (!boot_manager_set_prefix(manager, root)) {
                         return false;
                 }
         } else {
-                boot_manager_set_image_mode(manager, forced_image);
                 /* Default to "/", bail if it doesn't work. */
                 if (!boot_manager_set_prefix(manager, "/")) {
                         return false;

--- a/src/cli/ops/timeout.c
+++ b/src/cli/ops/timeout.c
@@ -37,7 +37,7 @@ bool cbm_command_set_timeout(int argc, char **argv)
         autofree(BootManager) *manager = NULL;
         bool update_efi_vars = false;
 
-        if (!cli_default_args_init(&argc, &argv, &root, NULL, &update_efi_vars)) {
+        if (!cli_default_args_init(&argc, &argv, &root, &update_efi_vars)) {
                 return false;
         }
 
@@ -102,7 +102,7 @@ bool cbm_command_get_timeout(int argc, char **argv)
         autofree(BootManager) *manager = NULL;
         bool update_efi_vars = false;
 
-        cli_default_args_init(&argc, &argv, &root, NULL, &update_efi_vars);
+        cli_default_args_init(&argc, &argv, &root, &update_efi_vars);
 
         manager = boot_manager_new();
         if (!manager) {

--- a/src/cli/ops/update.c
+++ b/src/cli/ops/update.c
@@ -25,10 +25,9 @@ bool cbm_command_update(int argc, char **argv)
 {
         autofree(char) *root = NULL;
         autofree(BootManager) *manager = NULL;
-        bool forced_image = false;
         bool update_efi_vars = true;
 
-        if (!cli_default_args_init(&argc, &argv, &root, &forced_image, &update_efi_vars)) {
+        if (!cli_default_args_init(&argc, &argv, &root, &update_efi_vars)) {
                 return false;
         }
 
@@ -45,27 +44,10 @@ bool cbm_command_update(int argc, char **argv)
                 return true;
         }
         if (root) {
-                autofree(char) *realp = NULL;
-
-                realp = realpath(root, NULL);
-                if (!realp) {
-                        LOG_FATAL("Path specified does not exist: %s", root);
-                        return false;
-                }
-                /* Anything not / is image mode */
-                if (!streq(realp, "/")) {
-                        boot_manager_set_image_mode(manager, true);
-                } else {
-                        boot_manager_set_image_mode(manager, forced_image);
-                }
-
-                /* CBM will check this again, we just needed to check for
-                 * image mode.. */
                 if (!boot_manager_set_prefix(manager, root)) {
                         return false;
                 }
         } else {
-                boot_manager_set_image_mode(manager, forced_image);
                 /* Default to "/", bail if it doesn't work. */
                 if (!boot_manager_set_prefix(manager, "/")) {
                         return false;

--- a/tests/check-grub2.c
+++ b/tests/check-grub2.c
@@ -88,7 +88,6 @@ START_TEST(bootman_grub2_image)
         fail_if(!m, "Failed to prepare update playground");
 
         /* Validate image install */
-        boot_manager_set_image_mode(m, true);
         fail_if(!boot_manager_update(m), "Failed to update image");
 }
 END_TEST
@@ -99,7 +98,6 @@ START_TEST(bootman_grub2_native)
 
         m = prepare_playground(&grub2_config);
         fail_if(!m, "Failed to prepare update playground");
-        boot_manager_set_image_mode(m, false);
 
         fail_if(!set_kernel_booted(&grub2_kernels[1], true), "Failed to set kernel as booted");
 
@@ -142,7 +140,6 @@ START_TEST(bootman_grub2_update_from_unknown)
 
         m = prepare_playground(&config);
         fail_if(!m, "Failed to prepare update playground");
-        boot_manager_set_image_mode(m, false);
 
         /* Hax the uname */
         boot_manager_set_uname(m, "unknown-uname");

--- a/tests/check-legacy.c
+++ b/tests/check-legacy.c
@@ -98,7 +98,6 @@ START_TEST(bootman_legacy_image)
         fail_if(!m, "Failed to prepare update playground");
 
         /* Validate image install */
-        boot_manager_set_image_mode(m, true);
         fail_if(!boot_manager_update(m), "Failed to update image");
 }
 END_TEST
@@ -109,7 +108,6 @@ START_TEST(bootman_legacy_native)
 
         m = prepare_playground(&legacy_config);
         fail_if(!m, "Failed to prepare update playground");
-        boot_manager_set_image_mode(m, false);
 
         fail_if(!set_kernel_booted(&legacy_kernels[1], true), "Failed to set kernel as booted");
 
@@ -152,7 +150,6 @@ START_TEST(bootman_legacy_update_from_unknown)
 
         m = prepare_playground(&config);
         fail_if(!m, "Failed to prepare update playground");
-        boot_manager_set_image_mode(m, false);
 
         /* Hax the uname */
         boot_manager_set_uname(m, "unknown-uname");
@@ -196,7 +193,7 @@ END_TEST
  *      - Request update of bootloader with *check* operation
  *      - Verify bootloader files are updated and match
  */
-static void internal_loader_test(bool image_mode)
+static void internal_loader_test(void)
 {
         autofree(BootManager) *m = NULL;
         PlaygroundConfig start_conf = { 0 };
@@ -209,7 +206,6 @@ static void internal_loader_test(bool image_mode)
 
         m = prepare_playground(&start_conf);
         fail_if(!m, "Fatal: Cannot initialise playground");
-        boot_manager_set_image_mode(m, image_mode);
 
         fail_if(!boot_manager_modify_bootloader(m, BOOTLOADER_OPERATION_INSTALL),
                 "Failed to install bootloader");
@@ -251,15 +247,9 @@ static void internal_loader_test(bool image_mode)
                 "Auto-updated bootloader doesn't match source");
 }
 
-START_TEST(bootman_legacy_update_image)
+START_TEST(bootman_legacy_update)
 {
-        internal_loader_test(true);
-}
-END_TEST
-
-START_TEST(bootman_legacy_update_native)
-{
-        internal_loader_test(false);
+        internal_loader_test();
 }
 END_TEST
 
@@ -274,9 +264,7 @@ static Suite *core_suite(void)
         tcase_add_test(tc, bootman_legacy_image);
         tcase_add_test(tc, bootman_legacy_native);
         tcase_add_test(tc, bootman_legacy_update_from_unknown);
-        tcase_add_test(tc, bootman_legacy_update_image);
-        tcase_add_test(tc, bootman_legacy_update_image);
-        tcase_add_test(tc, bootman_legacy_update_native);
+        tcase_add_test(tc, bootman_legacy_update);
         suite_add_tcase(s, tc);
 
         return s;

--- a/tests/check-syslinux.c
+++ b/tests/check-syslinux.c
@@ -98,7 +98,6 @@ START_TEST(bootman_legacy_image)
         fail_if(!m, "Failed to prepare update playground");
 
         /* Validate image install */
-        boot_manager_set_image_mode(m, true);
         fail_if(!boot_manager_update(m), "Failed to update image");
 }
 END_TEST
@@ -109,7 +108,6 @@ START_TEST(bootman_legacy_native)
 
         m = prepare_playground(&legacy_config);
         fail_if(!m, "Failed to prepare update playground");
-        boot_manager_set_image_mode(m, false);
 
         fail_if(!set_kernel_booted(&legacy_kernels[1], true), "Failed to set kernel as booted");
 
@@ -152,7 +150,6 @@ START_TEST(bootman_legacy_update_from_unknown)
 
         m = prepare_playground(&config);
         fail_if(!m, "Failed to prepare update playground");
-        boot_manager_set_image_mode(m, false);
 
         /* Hax the uname */
         boot_manager_set_uname(m, "unknown-uname");
@@ -196,7 +193,7 @@ END_TEST
  *      - Request update of bootloader with *check* operation
  *      - Verify bootloader files are updated and match
  */
-static void internal_loader_test(bool image_mode)
+static void internal_loader_test(void)
 {
         autofree(BootManager) *m = NULL;
         PlaygroundConfig start_conf = { 0 };
@@ -209,7 +206,6 @@ static void internal_loader_test(bool image_mode)
 
         m = prepare_playground(&start_conf);
         fail_if(!m, "Fatal: Cannot initialise playground");
-        boot_manager_set_image_mode(m, image_mode);
 
         fail_if(!boot_manager_modify_bootloader(m, BOOTLOADER_OPERATION_INSTALL),
                 "Failed to install bootloader");
@@ -251,15 +247,9 @@ static void internal_loader_test(bool image_mode)
                 "Auto-updated bootloader doesn't match source");
 }
 
-START_TEST(bootman_legacy_update_image)
+START_TEST(bootman_legacy_update)
 {
-        internal_loader_test(true);
-}
-END_TEST
-
-START_TEST(bootman_legacy_update_native)
-{
-        internal_loader_test(false);
+        internal_loader_test();
 }
 END_TEST
 
@@ -274,9 +264,7 @@ static Suite *core_suite(void)
         tcase_add_test(tc, bootman_legacy_image);
         tcase_add_test(tc, bootman_legacy_native);
         tcase_add_test(tc, bootman_legacy_update_from_unknown);
-        tcase_add_test(tc, bootman_legacy_update_image);
-        tcase_add_test(tc, bootman_legacy_update_image);
-        tcase_add_test(tc, bootman_legacy_update_native);
+        tcase_add_test(tc, bootman_legacy_update);
         suite_add_tcase(s, tc);
 
         return s;

--- a/tests/harness.c
+++ b/tests/harness.c
@@ -451,7 +451,6 @@ BootManager *prepare_playground(PlaygroundConfig *config)
                 }
         }
 
-        boot_manager_set_image_mode(m, false);
         if (config->uts_name && !boot_manager_set_uname(m, config->uts_name)) {
                 fprintf(stderr, "Cannot set given uname of %s\n", config->uts_name);
                 goto fail;


### PR DESCRIPTION
This patch attempts to unify both image and native mode. As a result of that we have
a single code path for both modes, reduce code complexity and maintenance effort
keeping executions *consistent* across these two major scenarios.

We may argue that with this changes we're adding "extra" operations to former image
mode operations - i.e collection kernels on image mode doesn't make sense and just
add extra work, however these operations should be *consistent* across different
scenarios and all of them will not impose any extra runtime overhead more than a few
extra checks, in the collecting kernels examples we'll not do anything if don't find
extra kernels to collect.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>