### PR TITLE
timeout/update: don't allocate/free manager twice

### DIFF
--- a/src/cli/ops/timeout.c
+++ b/src/cli/ops/timeout.c
@@ -93,7 +93,7 @@ bool cbm_command_set_timeout(int argc, char **argv)
                 fprintf(stdout, "New timeout value is: %d\n", n_val);
         }
 
-        return cbm_command_update(argc, argv);
+        return cbm_command_update_do(manager);
 }
 
 bool cbm_command_get_timeout(int argc, char **argv)

--- a/src/cli/ops/update.c
+++ b/src/cli/ops/update.c
@@ -20,6 +20,7 @@
 #include "cli.h"
 #include "log.h"
 #include "nica/files.h"
+#include "update.h"
 
 bool cbm_command_update(int argc, char **argv)
 {
@@ -40,10 +41,19 @@ bool cbm_command_update(int argc, char **argv)
 
         boot_manager_set_update_efi_vars(manager, update_efi_vars);
         
+        return cbm_command_update_do(manager);
+}
+
+bool cbm_command_update_do(BootManager *manager)
+{
+        autofree(char) *root = NULL;
+        bool forced_image = false;
+
         if (!boot_manager_detect_kernel_dir(root)) {
                 fprintf(stderr, "No kernels detected on system to update\n");
                 return true;
         }
+
         if (root) {
                 autofree(char) *realp = NULL;
 

--- a/src/cli/ops/update.h
+++ b/src/cli/ops/update.h
@@ -11,9 +11,11 @@
 
 #pragma once
 
+#include "bootman.h"
 #include "cli.h"
 
 bool cbm_command_update(int argc, char **argv);
+bool cbm_command_update_do(BootManager *manager);
 
 /*
  * Editor modelines  -  https://www.wireshark.org/tools/modelines.html


### PR DESCRIPTION
Avoid parsing flags, allocating BootManager twice when calling update
from time out command.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>