### PR TITLE
get_boot_device: fix efi loader path matching

### DIFF
--- a/src/lib/files.c
+++ b/src/lib/files.c
@@ -92,7 +92,7 @@ char *get_boot_device()
         autofree(char) *glob_path = NULL;
         autofree(char) *dev_path = NULL;
 
-        glob_path = string_printf("%s/firmware/efi/efivars/LoaderDevicePartUUID*",
+        glob_path = string_printf("%s/firmware/efi/efivars/LoaderDevicePartUUID-*",
                                   cbm_system_get_sysfs_path());
 
         glob(glob_path, GLOB_DOOFFS, NULL, &glo);


### PR DESCRIPTION
We've found some cases where the path to LoaderDevicePartUUID will have
some "virtual" entries containing some "garbage" in the path. This patch
makes sure we always match only the right formatted ones.

Fixes: #199

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>