### PR TITLE
fix regression introduced by 512323d

### DIFF
--- a/src/cli/ops/timeout.c
+++ b/src/cli/ops/timeout.c
@@ -93,7 +93,7 @@ bool cbm_command_set_timeout(int argc, char **argv)
                 fprintf(stdout, "New timeout value is: %d\n", n_val);
         }
 
-        return cbm_command_update_do(manager);
+        return cbm_command_update_do(manager, root, false);
 }
 
 bool cbm_command_get_timeout(int argc, char **argv)

--- a/src/cli/ops/update.c
+++ b/src/cli/ops/update.c
@@ -41,14 +41,11 @@ bool cbm_command_update(int argc, char **argv)
 
         boot_manager_set_update_efi_vars(manager, update_efi_vars);
         
-        return cbm_command_update_do(manager);
+        return cbm_command_update_do(manager, root, forced_image);
 }
 
-bool cbm_command_update_do(BootManager *manager)
+bool cbm_command_update_do(BootManager *manager, char *root, bool forced_image)
 {
-        autofree(char) *root = NULL;
-        bool forced_image = false;
-
         if (!boot_manager_detect_kernel_dir(root)) {
                 fprintf(stderr, "No kernels detected on system to update\n");
                 return true;

--- a/src/cli/ops/update.h
+++ b/src/cli/ops/update.h
@@ -15,7 +15,7 @@
 #include "cli.h"
 
 bool cbm_command_update(int argc, char **argv);
-bool cbm_command_update_do(BootManager *manager);
+bool cbm_command_update_do(BootManager *manager, char *root, bool forced_image);
 
 /*
  * Editor modelines  -  https://www.wireshark.org/tools/modelines.html


### PR DESCRIPTION
With the commit 512323d we started ignoring the --path flag therefore breaking image
mode use cases. This patch brings back --path flag.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>