### PR TITLE
legacy boot

### DIFF
--- a/src/bootloaders/extlinux.c
+++ b/src/bootloaders/extlinux.c
@@ -71,6 +71,9 @@ static bool extlinux_init(const BootManager *manager)
                 boot_device = get_boot_device();
         }
 
+        CHECK_ERR_RET_VAL(!boot_device, false, "No boot partition found, you need to "
+                          "mark the boot partition with \"legacy_boot\" flag.");
+
         extlinux_cmd = string_printf("%s/usr/bin/extlinux -i %s --device %s &> /dev/null",
                                      prefix, base_path, boot_device);
 

--- a/src/bootloaders/syslinux.c
+++ b/src/bootloaders/syslinux.c
@@ -77,6 +77,9 @@ static bool syslinux_init(const BootManager *manager)
                 boot_device = get_boot_device();
         }
 
+        CHECK_ERR_RET_VAL(!boot_device, false, "No boot partition found, you need to "
+                          "mark the boot partition with \"legacy_boot\" flag.");
+
         // syslinux -U will not work with a partuuid, the effect of "install" and
         // "update" will always be the same, so assume install for all scenarios
         syslinux_cmd = string_printf("%s/usr/bin/syslinux -i %s &> /dev/null",


### PR DESCRIPTION
If we don't find the boot partition then we warn the user exit, currently we
segfault.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>