### PR TITLE
Fix legacy boot

### DIFF
--- a/src/bootloaders/extlinux.c
+++ b/src/bootloaders/extlinux.c
@@ -194,7 +194,7 @@ static bool extlinux_set_default_kernel(const BootManager *manager, const Kernel
         }
 
         /* If the file is the same, don't write it again or sync */
-        if (file_get_text(config_path, &old_conf)) {
+        if (cbm_file_has_content(config_path) && file_get_text(config_path, &old_conf)) {
                 if (streq(old_conf, writer->buffer)) {
                         return true;
                 }

--- a/src/bootloaders/syslinux.c
+++ b/src/bootloaders/syslinux.c
@@ -223,7 +223,7 @@ static bool syslinux_set_default_kernel(const BootManager *manager, const Kernel
         }
 
         /* If the file is the same, don't write it again or sync */
-        if (file_get_text(config_path, &old_conf)) {
+        if (cbm_file_has_content(config_path) && file_get_text(config_path, &old_conf)) {
                 if (streq(old_conf, writer->buffer)) {
                         return true;
                 }

--- a/src/bootloaders/syslinux.c
+++ b/src/bootloaders/syslinux.c
@@ -82,7 +82,7 @@ static bool syslinux_init(const BootManager *manager)
 
         // syslinux -U will not work with a partuuid, the effect of "install" and
         // "update" will always be the same, so assume install for all scenarios
-        syslinux_cmd = string_printf("%s/usr/bin/syslinux -i %s &> /dev/null",
+        syslinux_cmd = string_printf("%s/usr/bin/syslinux-nomtools -i %s &> /dev/null",
                                      prefix, boot_device);
 
         partition_index = get_partition_index(prefix, boot_device);

--- a/src/lib/files.c
+++ b/src/lib/files.c
@@ -169,6 +169,32 @@ static bool get_parent_disk_devno(char *path, dev_t *diskdevno)
         return true;
 }
 
+bool cbm_file_has_content(char *path)
+{
+        int fd = -1;
+        struct stat st = { 0 };
+        ssize_t length = -1;
+
+        if (!nc_file_exists(path)) {
+                return false;
+        }
+
+        fd = open(path, O_RDONLY);
+        if (fd < 0) {
+                return false;
+        }
+
+        if (fstat(fd, &st) != 0) {
+                close(fd);
+                return false;
+        }
+
+        length = st.st_size;
+        close(fd);
+
+        return length != 0;
+}
+
 char *get_parent_disk(char *path)
 {
         dev_t devt;

--- a/src/lib/files.h
+++ b/src/lib/files.h
@@ -181,6 +181,11 @@ bool cbm_path_check(const char *path, const char *resolved);
 bool cbm_is_dir_empty(const char *path);
 
 /**
+ * Check if @path exists and if it's empty.
+ */
+bool cbm_file_has_content(char *path);
+
+/**
  * Ensure a stack pointer vs a heap pointer, to save on copies
  */
 #define CBM_MAPPED_FILE_INIT &(CbmMappedFile){ 0 };


### PR DESCRIPTION
+ syslinux was broken due an mtool dependency issue, we better eliminate the dependency and use syslinux-nomtools - bonus point we reduce the footprint (beneficial to small images).

+ sanity check configuration file before comparing previous versions and avoid segfaulting.