### PR TITLE
mkrelease: put together all the required steps before release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@
 
 # distributed tarball
 clr-boot-manager-*.tar.xz
-
+clr-boot-manager-*.tar.xz.asc

--- a/scripts/mkrelease.sh
+++ b/scripts/mkrelease.sh
@@ -3,22 +3,61 @@
 # This file is part of clr-boot-manager.
 #
 # Copyright © 2017 Ikey Doherty
+# Copyright © 2020 Intel Corporation
 #
 # clr-boot-manager is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public License as
 # published by the Free Software Foundation; either version 2.1
 # of the License, or (at your option) any later version.
 #
+
 set -e
+
+pkg="clr-boot-manager"
+
+print_help() {
+    echo -e "mkrelease.sh [--help] [options]
+
+mkrelease.sh executes all the required steps before cutting a new release(set
+new version, creates bundled artifacts including vendored components, creates
+the release tag etc).
+
+Help Options:
+    -h, --help		Show this help list
+
+Options:
+    -n, --new-version	The release's new version"
+}
+
+for curr in "$@"; do
+    case $curr in
+	"--new-version"|"-n")
+	    version=$2
+	    shift
+	    shift
+	    ;;
+	"--help"|"-h")
+	    print_help;
+	    exit 0;;
+    esac
+done
+
+if [ "$version" == "" ]; then
+    echo "No version provided, please use \"--new-version\" flag. Use --help for more information."
+fi
+
+echo "${version}" > VERSION
+git commit -a -s -m "v${version} release"
+git tag "v${version}"
 
 git submodule init
 git submodule update
 
-VERSION=$(cat ./VERSION)
-NAME="clr-boot-manager"
-./scripts/git-archive-all.sh --format tar --prefix ${NAME}-${VERSION}/ --verbose -t HEAD ${NAME}-${VERSION}.tar
-xz -9 "${NAME}-${VERSION}.tar"
+./scripts/git-archive-all.sh --format tar --prefix ${pkg}-${version}/ \
+			     --verbose -t "v${version}" ${pkg}-${version}.tar
+
+xz -9 "${pkg}-${version}.tar"
 
 # Automatically sign the tarball
-gpg --armor --detach-sign "${NAME}-${VERSION}.tar.xz"
-gpg --verify "${NAME}-${VERSION}.tar.xz.asc"
+gpg --armor --detach-sign "${pkg}-${version}.tar.xz"
+gpg --verify "${pkg}-${version}.tar.xz.asc"


### PR DESCRIPTION
Make our life easier, put together all the required steps before cutting a new
release instead of having to remember it all.

Change the VERSION file, create the release commit and tag. Bonus point added a
--help flag so we can easily remember how this script works.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>