### PR TITLE
systemd compatibility

### DIFF
--- a/src/bootloaders/systemd-class.c
+++ b/src/bootloaders/systemd-class.c
@@ -351,14 +351,14 @@ bool sd_class_set_default_kernel(const BootManager *manager, const Kernel *kerne
 
         if (timeout > 0) {
                 /* Set the timeout as configured by the user */
-                item_name = string_printf("timeout %d\ndefault %s-%s-%s-%d\n",
+                item_name = string_printf("timeout %d\ndefault %s-%s-%s-%d.conf\n",
                                           timeout,
                                           prefix,
                                           kernel->meta.ktype,
                                           kernel->meta.version,
                                           kernel->meta.release);
         } else {
-                item_name = string_printf("default %s-%s-%s-%d\n",
+                item_name = string_printf("default %s-%s-%s-%d.conf\n",
                                           prefix,
                                           kernel->meta.ktype,
                                           kernel->meta.version,


### PR DESCRIPTION
With recent systemd changes cbm use cases will break if we don't add ".conf" to the
loader.conf default entry configuration.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>