### PR TITLE
Add support for Btrfs subvolumes 

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -44,6 +44,12 @@ ccompiler = meson.get_compiler('c')
 dep_blkid = dependency('blkid')
 dep_check = dependency('check', version: '>= 0.9')
 
+# other deps
+dep_btrfs = ccompiler.find_library('btrfsutil')
+if not ccompiler.has_header('btrfsutil.h')
+    error('Cannot find btrfsutil.h. Is btrfs-progs-dev(el) installed?')
+endif
+
 # Grab necessary paths
 path_prefix = get_option('prefix')
 path_bindir = join_paths(path_prefix, get_option('bindir'))

--- a/src/bootloaders/grub2.c
+++ b/src/bootloaders/grub2.c
@@ -240,6 +240,11 @@ bool grub2_write_kernel(const Grub2Config *config, const Kernel *kernel)
                                          "rd.luks.uuid=%s ",
                                          config->root_dev->luks_uuid);
         }
+        if (config->root_dev->btrfs_sub) {
+                cbm_writer_append_printf(config->writer,
+                                         "rootflags=subvol=%s ",
+                                         config->root_dev->btrfs_sub);
+        }
 
         /* Finish it off with the command line options */
         cbm_writer_append_printf(config->writer, "%s\"\n", kernel->meta.cmdline);

--- a/src/bootloaders/syslinux-common.c
+++ b/src/bootloaders/syslinux-common.c
@@ -175,6 +175,10 @@ bool syslinux_common_set_default_kernel(const BootManager *manager, const Kernel
                 if (root_dev->luks_uuid) {
                         cbm_writer_append_printf(writer, "rd.luks.uuid=%s ", root_dev->luks_uuid);
                 }
+                /* Add Btrfs information if relevant */
+                if (root_dev->btrfs_sub) {
+                        cbm_writer_append_printf(writer, "rootflags=subvol=%s ", root_dev->btrfs_sub);
+                }
 
                 /* Write out the cmdline */
                 cbm_writer_append_printf(writer, "%s\n", k->meta.cmdline);

--- a/src/bootloaders/systemd-class.c
+++ b/src/bootloaders/systemd-class.c
@@ -269,6 +269,10 @@ bool sd_class_install_kernel(const BootManager *manager, const Kernel *kernel)
         if (root_dev->luks_uuid) {
                 cbm_writer_append_printf(writer, "rd.luks.uuid=%s ", root_dev->luks_uuid);
         }
+        /* Add Btrfs information if relevant */
+        if (root_dev->btrfs_sub) {
+                cbm_writer_append_printf(writer, "rootflags=subvol=%s ", root_dev->btrfs_sub);
+        }
 
         /* Finish it off with the command line options */
         cbm_writer_append_printf(writer, "%s\n", kernel->meta.cmdline);

--- a/src/lib/blkid_stub.c
+++ b/src/lib/blkid_stub.c
@@ -37,6 +37,7 @@ static CbmBlkidOps default_blkid_ops = {
         .probe_set_superblocks_flags = blkid_probe_set_superblocks_flags,
         .probe_enable_partitions = blkid_probe_enable_partitions,
         .probe_set_partitions_flags = blkid_probe_set_partitions_flags,
+        .probe_get_wholedisk_devno = blkid_probe_get_wholedisk_devno,
         .probe_lookup_value = blkid_probe_lookup_value,
         .do_safeprobe = blkid_do_safeprobe,
         .free_probe = blkid_free_probe,
@@ -54,6 +55,7 @@ static CbmBlkidOps default_blkid_ops = {
 
         /* Misc */
         .devno_to_wholedisk = cbm_blkid_devno_to_wholedisk_wrapped,
+        .devno_to_devname = blkid_devno_to_devname,
 };
 
 /**
@@ -79,6 +81,7 @@ void cbm_blkid_set_vtable(CbmBlkidOps *ops)
         assert(blkid_ops->probe_set_superblocks_flags != NULL);
         assert(blkid_ops->probe_enable_partitions != NULL);
         assert(blkid_ops->probe_set_partitions_flags != NULL);
+        assert(blkid_ops->probe_get_wholedisk_devno != NULL);
         assert(blkid_ops->probe_lookup_value != NULL);
         assert(blkid_ops->do_safeprobe != NULL);
         assert(blkid_ops->free_probe != NULL);
@@ -96,6 +99,7 @@ void cbm_blkid_set_vtable(CbmBlkidOps *ops)
 
         /* misc */
         assert(blkid_ops->devno_to_wholedisk != NULL);
+        assert(blkid_ops->devno_to_devname != NULL);
 }
 
 /**
@@ -139,6 +143,11 @@ int cbm_blkid_probe_lookup_value(blkid_probe pr, const char *name, const char **
 void cbm_blkid_free_probe(blkid_probe pr)
 {
         blkid_ops->free_probe(pr);
+}
+
+dev_t cbm_probe_get_wholedisk_devno(blkid_probe pr)
+{
+        return blkid_ops->probe_get_wholedisk_devno(pr);
 }
 
 /**
@@ -191,6 +200,11 @@ const char *cbm_blkid_parttable_get_type(blkid_parttable tab)
 int cbm_blkid_devno_to_wholedisk(dev_t dev, char *diskname, size_t len, dev_t *diskdevno)
 {
         return blkid_ops->devno_to_wholedisk(dev, diskname, len, diskdevno);
+}
+
+char *cbm_blkid_devno_to_devname(dev_t dev)
+{
+        return blkid_ops->devno_to_devname(dev);
 }
 
 /*

--- a/src/lib/blkid_stub.h
+++ b/src/lib/blkid_stub.h
@@ -28,6 +28,7 @@ typedef struct CbmBlkidOps {
         int (*probe_lookup_value)(blkid_probe pr, const char *name, const char **data, size_t *len);
         int (*do_safeprobe)(blkid_probe pr);
         void (*free_probe)(blkid_probe pr);
+        dev_t (*probe_get_wholedisk_devno)(blkid_probe pr);
 
         /* Partition functions */
         blkid_partlist (*probe_get_partitions)(blkid_probe pr);
@@ -42,6 +43,7 @@ typedef struct CbmBlkidOps {
 
         /* Misc functions */
         int (*devno_to_wholedisk)(dev_t dev, char *diskname, size_t len, dev_t *diskdevno);
+        char *(*devno_to_devname)(dev_t dev);
 } CbmBlkidOps;
 
 /**
@@ -109,6 +111,7 @@ int cbm_blkid_probe_set_partitions_flags(blkid_probe pr, int flags);
 int cbm_blkid_do_safeprobe(blkid_probe pr);
 int cbm_blkid_probe_lookup_value(blkid_probe pr, const char *name, const char **data, size_t *len);
 void cbm_blkid_free_probe(blkid_probe pr);
+dev_t cbm_probe_get_wholedisk_devno(blkid_probe pr);
 
 /**
  * Partition related wrappers
@@ -129,6 +132,7 @@ const char *cbm_blkid_parttable_get_type(blkid_parttable tab);
  * Misc related wrappers
  */
 int cbm_blkid_devno_to_wholedisk(dev_t dev, char *diskname, size_t len, dev_t *diskdevno);
+char *cbm_blkid_devno_to_devname(dev_t dev);
 
 /*
  * Editor modelines  -  https://www.wireshark.org/tools/modelines.html

--- a/src/lib/files.h
+++ b/src/lib/files.h
@@ -143,6 +143,14 @@ bool cbm_is_mounted(const char *path);
 char *cbm_get_mountpoint_for_device(const char *device);
 
 /**
+ * Determine the device for the given mountpoint
+ *
+ * @param mount Mount point to get the device for
+ * @return Device path for the mount point, or NULL if none was found.
+ */
+char *cbm_get_device_for_mountpoint(const char *mount);
+
+/**
  * Determine whether the system is booted using UEFI
  */
 bool cbm_system_has_uefi(void);

--- a/src/lib/probe.c
+++ b/src/lib/probe.c
@@ -203,17 +203,17 @@ CbmDeviceProbe *cbm_probe_path(const char *path)
                 LOG_ERROR("Path does not exist: %s", path);
                 return NULL;
         }
-        probe.dev = st.st_dev;
 
-        devnode = cbm_system_devnode_to_devpath(probe.dev);
+        devnode = cbm_system_get_device_for_mountpoint(path);
         if (!devnode) {
+                LOG_ERROR("No device for path: %s", path);
                 DECLARE_OOM();
                 return NULL;
         }
 
         blk_probe = cbm_blkid_new_probe_from_filename(devnode);
         if (!blk_probe) {
-                fprintf(stderr, "Unable to probe %u:%u", major(st.st_dev), minor(st.st_dev));
+                fprintf(stderr, "Unable to probe device %s", devnode);
                 return NULL;
         }
 

--- a/src/lib/probe.h
+++ b/src/lib/probe.h
@@ -26,6 +26,7 @@ typedef struct CbmDeviceProbe {
         char *uuid;      /**< UUID for all partition types */
         char *part_uuid; /**< PartUUID for GPT partitions */
         char *luks_uuid; /**< Parent LUKS UUID for the partition */
+        char *btrfs_sub; /**< Btrfs subvolume of the rootfs */
         bool gpt;        /**<Whether this device belongs to a GPT disk */
 } CbmDeviceProbe;
 

--- a/src/lib/probe.h
+++ b/src/lib/probe.h
@@ -26,7 +26,6 @@ typedef struct CbmDeviceProbe {
         char *uuid;      /**< UUID for all partition types */
         char *part_uuid; /**< PartUUID for GPT partitions */
         char *luks_uuid; /**< Parent LUKS UUID for the partition */
-        dev_t dev;       /**< The device itself */
         bool gpt;        /**<Whether this device belongs to a GPT disk */
 } CbmDeviceProbe;
 

--- a/src/lib/system_stub.c
+++ b/src/lib/system_stub.c
@@ -55,6 +55,7 @@ static CbmSystemOps default_system_ops = {
         .system = system,
         .is_mounted = cbm_is_mounted,
         .get_mountpoint_for_device = cbm_get_mountpoint_for_device,
+        .get_device_for_mountpoint = cbm_get_device_for_mountpoint,
         .devnode_to_devpath = cbm_devnode_to_devpath,
         .get_sysfs_path = cbm_get_sysfs_path,
         .get_devfs_path = cbm_get_devfs_path,
@@ -112,6 +113,11 @@ bool cbm_system_is_mounted(const char *target)
 char *cbm_system_get_mountpoint_for_device(const char *device)
 {
         return system_ops->get_mountpoint_for_device(device);
+}
+
+char *cbm_system_get_device_for_mountpoint(const char *device)
+{
+        return system_ops->get_device_for_mountpoint(device);
 }
 
 char *cbm_system_devnode_to_devpath(dev_t d)

--- a/src/lib/system_stub.h
+++ b/src/lib/system_stub.h
@@ -30,6 +30,7 @@ typedef struct CbmSystemOps {
         /* wrap cbm lib functions */
         bool (*is_mounted)(const char *target);
         char *(*get_mountpoint_for_device)(const char *device);
+        char *(*get_device_for_mountpoint)(const char *mount);
 
         /* exec family */
         int (*system)(const char *command);
@@ -69,6 +70,11 @@ bool cbm_system_is_mounted(const char *target);
  * Get the mountpoint for the given device path
  */
 char *cbm_system_get_mountpoint_for_device(const char *device);
+
+/**
+ * Get the device path for a given mountpoint
+ */
+char *cbm_system_get_device_for_mountpoint(const char *device);
 
 /**
  * Wrap the umount syscall

--- a/src/meson.build
+++ b/src/meson.build
@@ -68,6 +68,7 @@ libcbm_includes = [
 libcbm_dependencies = [
     link_libnica,
     dep_blkid,
+    dep_btrfs,
 ]
 
 # Special constraints for efi functionality

--- a/tests/blkid-harness.h
+++ b/tests/blkid-harness.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "blkid_stub.h"
+#include <sys/sysmacros.h>
 
 const char *DEFAULT_UUID = "Test-UUID";
 const char *DEFAULT_PART_UUID = "Test-PartUUID";
@@ -46,6 +47,12 @@ static inline int test_blkid_probe_set_partitions_flags(__cbm_unused__ blkid_pro
                                                         __cbm_unused__ int flags)
 {
         return 0;
+}
+
+static inline dev_t test_blkid_probe_get_wholedisk_devno(__cbm_unused__ blkid_probe pr)
+{
+        /* Prevent legacy testing */
+        return makedev(0, 0);
 }
 
 static inline int test_blkid_do_safeprobe(__cbm_unused__ blkid_probe pr)
@@ -118,6 +125,12 @@ static inline int test_blkid_devno_to_wholedisk(__cbm_unused__ dev_t dev,
         return -1;
 }
 
+static inline char *test_blkid_devno_to_devname(dev_t dev)
+{
+    return string_printf("%s/dev/block/%u:%u",
+                         TOP_BUILD_DIR "/tests/update_playground", major(dev), minor(dev));
+}
+
 static inline blkid_parttable test_blkid_partlist_get_table(__cbm_unused__ blkid_partlist ls)
 {
         /* Return a "valid" partition table */
@@ -140,6 +153,7 @@ CbmBlkidOps BlkidTestOps = {
         .probe_set_superblocks_flags = test_blkid_probe_set_superblocks_flags,
         .probe_enable_partitions = test_blkid_probe_enable_partitions,
         .probe_set_partitions_flags = test_blkid_probe_set_partitions_flags,
+        .probe_get_wholedisk_devno = test_blkid_probe_get_wholedisk_devno,
         .probe_lookup_value = test_blkid_probe_lookup_value,
         .do_safeprobe = test_blkid_do_safeprobe,
         .free_probe = test_blkid_free_probe,
@@ -157,6 +171,7 @@ CbmBlkidOps BlkidTestOps = {
 
         /* Misc */
         .devno_to_wholedisk = test_blkid_devno_to_wholedisk,
+        .devno_to_devname = test_blkid_devno_to_devname,
 };
 
 /*

--- a/tests/check-legacy.c
+++ b/tests/check-legacy.c
@@ -44,6 +44,14 @@ static inline int legacy_devno_to_wholedisk(__cbm_unused__ dev_t dev, __cbm_unus
 }
 
 /**
+ * Coerce legacy lookup
+ */
+static inline dev_t legacy_probe_get_wholedisk_devno(__cbm_unused__ blkid_probe pr)
+{
+        return makedev(8, 8);
+}
+
+/**
  * Forces detection of GPT legacy boot partition
  */
 static inline unsigned long long legacy_partition_get_flags(__cbm_unused__ blkid_partition par)
@@ -290,6 +298,7 @@ int main(void)
         /* override test ops for legacy testing */
         CbmBlkidOps blkid_ops = BlkidTestOps;
         blkid_ops.devno_to_wholedisk = legacy_devno_to_wholedisk;
+        blkid_ops.probe_get_wholedisk_devno = legacy_probe_get_wholedisk_devno;
         blkid_ops.partition_get_flags = legacy_partition_get_flags;
         blkid_ops.partition_get_uuid = legacy_partition_get_uuid;
 

--- a/tests/check-probe.c
+++ b/tests/check-probe.c
@@ -67,6 +67,14 @@ static inline int gpt_devno_to_wholedisk(__cbm_unused__ dev_t dev, __cbm_unused_
 }
 
 /**
+ * Coerce legacy lookup
+ */
+static inline dev_t gpt_probe_get_wholedisk_devno(__cbm_unused__ blkid_probe pr)
+{
+        return makedev(8, 8);
+}
+
+/**
  * This will force the tests to use the GPT detection codepaths
  */
 static CbmBlkidOps gpt_blkid_ops = {
@@ -75,6 +83,7 @@ static CbmBlkidOps gpt_blkid_ops = {
         .probe_set_superblocks_flags = test_blkid_probe_set_superblocks_flags,
         .probe_enable_partitions = test_blkid_probe_enable_partitions,
         .probe_set_partitions_flags = test_blkid_probe_set_partitions_flags,
+        .probe_get_wholedisk_devno = gpt_probe_get_wholedisk_devno,
         .probe_lookup_value = test_blkid_probe_lookup_value,
         .do_safeprobe = test_blkid_do_safeprobe,
         .free_probe = test_blkid_free_probe,
@@ -86,6 +95,7 @@ static CbmBlkidOps gpt_blkid_ops = {
         .partlist_get_table = test_blkid_partlist_get_table,
         .parttable_get_type = test_blkid_parttable_get_type,
         .devno_to_wholedisk = gpt_devno_to_wholedisk,
+        .devno_to_devname = test_blkid_devno_to_devname,
 };
 
 static inline const char *mbr_parttable_get_type(__cbm_unused__ blkid_parttable tab)
@@ -102,6 +112,7 @@ static CbmBlkidOps mbr_blkid_ops = {
         .probe_set_superblocks_flags = test_blkid_probe_set_superblocks_flags,
         .probe_enable_partitions = test_blkid_probe_enable_partitions,
         .probe_set_partitions_flags = test_blkid_probe_set_partitions_flags,
+        .probe_get_wholedisk_devno = test_blkid_probe_get_wholedisk_devno,
         .probe_lookup_value = test_blkid_probe_lookup_value,
         .do_safeprobe = test_blkid_do_safeprobe,
         .free_probe = test_blkid_free_probe,
@@ -113,6 +124,7 @@ static CbmBlkidOps mbr_blkid_ops = {
         .partlist_get_table = test_blkid_partlist_get_table,
         .parttable_get_type = mbr_parttable_get_type,
         .devno_to_wholedisk = gpt_devno_to_wholedisk,
+        .devno_to_devname = test_blkid_devno_to_devname,
 };
 
 static void bootman_probe_set_gpt_vtables(void)

--- a/tests/check-select-bootloader.c
+++ b/tests/check-select-bootloader.c
@@ -182,6 +182,14 @@ static inline int legacy_devno_to_wholedisk(__cbm_unused__ dev_t dev, __cbm_unus
 }
 
 /**
+ * Coerce legacy lookup
+ */
+static inline dev_t legacy_probe_get_wholedisk_devno(__cbm_unused__ blkid_probe pr)
+{
+        return makedev(8, 8);
+}
+
+/**
  * Forces detection of GPT legacy boot partition
  */
 static inline unsigned long long legacy_partition_get_flags(__cbm_unused__ blkid_partition par)
@@ -206,6 +214,7 @@ static CbmBlkidOps legacy_blkid_ops = {
         .probe_set_superblocks_flags = test_blkid_probe_set_superblocks_flags,
         .probe_enable_partitions = test_blkid_probe_enable_partitions,
         .probe_set_partitions_flags = test_blkid_probe_set_partitions_flags,
+        .probe_get_wholedisk_devno = legacy_probe_get_wholedisk_devno,
         .probe_lookup_value = test_blkid_probe_lookup_value,
         .do_safeprobe = test_blkid_do_safeprobe,
         .free_probe = test_blkid_free_probe,
@@ -217,6 +226,7 @@ static CbmBlkidOps legacy_blkid_ops = {
         .partlist_get_table = test_blkid_partlist_get_table,
         .parttable_get_type = test_blkid_parttable_get_type,
         .devno_to_wholedisk = legacy_devno_to_wholedisk,
+        .devno_to_devname = test_blkid_devno_to_devname,
 };
 
 static void bootman_select_set_legacy_vtables(void)
@@ -303,6 +313,7 @@ static CbmBlkidOps grub2_blkid_ops = {
         .probe_set_superblocks_flags = test_blkid_probe_set_superblocks_flags,
         .probe_enable_partitions = test_blkid_probe_enable_partitions,
         .probe_set_partitions_flags = test_blkid_probe_set_partitions_flags,
+        .probe_get_wholedisk_devno = test_blkid_probe_get_wholedisk_devno,
         .probe_lookup_value = grub2_blkid_probe_lookup_value,
         .do_safeprobe = test_blkid_do_safeprobe,
         .free_probe = test_blkid_free_probe,
@@ -314,6 +325,7 @@ static CbmBlkidOps grub2_blkid_ops = {
         .partlist_get_table = test_blkid_partlist_get_table,
         .parttable_get_type = test_blkid_parttable_get_type,
         .devno_to_wholedisk = test_blkid_devno_to_wholedisk,
+        .devno_to_devname = test_blkid_devno_to_devname,
 };
 
 static void bootman_select_set_grub2_vtables(void)

--- a/tests/check-syslinux.c
+++ b/tests/check-syslinux.c
@@ -44,6 +44,14 @@ static inline int legacy_devno_to_wholedisk(__cbm_unused__ dev_t dev, __cbm_unus
 }
 
 /**
+ * Coerce legacy lookup
+ */
+static inline dev_t legacy_probe_get_wholedisk_devno(__cbm_unused__ blkid_probe pr)
+{
+        return makedev(8, 8);
+}
+
+/**
  * Forces detection of GPT legacy boot partition
  */
 static inline unsigned long long legacy_partition_get_flags(__cbm_unused__ blkid_partition par)
@@ -290,6 +298,7 @@ int main(void)
         /* override test ops for legacy testing */
         CbmBlkidOps blkid_ops = BlkidTestOps;
         blkid_ops.devno_to_wholedisk = legacy_devno_to_wholedisk;
+        blkid_ops.probe_get_wholedisk_devno = legacy_probe_get_wholedisk_devno;
         blkid_ops.partition_get_flags = legacy_partition_get_flags;
         blkid_ops.partition_get_uuid = legacy_partition_get_uuid;
 

--- a/tests/system-harness.h
+++ b/tests/system-harness.h
@@ -41,9 +41,14 @@ static inline char *test_get_mountpoint_for_device(__cbm_unused__ const char *de
         return NULL;
 }
 
-static inline char *test_devnode_to_devpath(__cbm_unused__ dev_t d)
+static inline char *test_get_device_for_mountpoint(__cbm_unused__ const char *device)
 {
         return string_printf("%s/dev/testRoot", TOP_BUILD_DIR "/tests/update_playground");
+}
+
+static inline char *test_devnode_to_devpath(__cbm_unused__ dev_t d)
+{
+        return test_get_device_for_mountpoint(NULL);
 }
 
 static inline const char *test_get_sysfs_path(void)
@@ -66,6 +71,7 @@ CbmSystemOps SystemTestOps = {
         .system = test_system,
         .is_mounted = test_is_mounted,
         .get_mountpoint_for_device = test_get_mountpoint_for_device,
+        .get_device_for_mountpoint = test_get_device_for_mountpoint,
         .devnode_to_devpath = test_devnode_to_devpath,
         .get_sysfs_path = test_get_sysfs_path,
         .get_devfs_path = test_get_devfs_path,


### PR DESCRIPTION
This PR builds on #238 with support for having the root filesystem on a Btrfs subvolume.

Note: this is only actually [this commit](https://github.com/clearlinux/clr-boot-manager/commit/e0506fe3f294254d3f017ae4bb56273083712695), as #238 is included. I will rebase after #238 is merged.