### PR TITLE
Fix LUKS glob order

### DIFF
--- a/src/lib/probe.c
+++ b/src/lib/probe.c
@@ -72,7 +72,7 @@ static char *cbm_get_luks_uuid(const char *part)
         /* i.e. /sys/block/dm-1/slaves/dm-0/slaves/sdb1/dev
          * or /sys/block/dm-1/slaves/sdb1/dev
          */
-        npath = string_printf("%s/block/%s/slaves/*{,/slaves/*}/dev", sys, part);
+        npath = string_printf("%s/block/%s/slaves/*{/slaves/*,}/dev", sys, part);
 
         glob(npath, GLOB_DOOFFS | GLOB_BRACE, NULL, &glo);
 


### PR DESCRIPTION
As noted in #134, I believe the order is the wrong way round.

I have tested this on Solus with Btrfs on LUKS, and Btrfs on LVM on LUKS. I was unable to test this on a clean Clear Linux or Solus install, as both failed to install with disk encryption in a (BIOS) VM.

Resolves #134