### PR TITLE
bootman: only do partitionless boot when the bootloader supports it

### DIFF
--- a/src/bootloaders/bootloader.h
+++ b/src/bootloaders/bootloader.h
@@ -35,12 +35,13 @@ typedef int (*boot_loader_caps)(const BootManager *);
 
 typedef enum {
         BOOTLOADER_CAP_MIN = 1 << 0,
-        BOOTLOADER_CAP_UEFI = 1 << 1,   /**<Bootloader supports UEFI */
-        BOOTLOADER_CAP_GPT = 1 << 2,    /**<Bootloader supports GPT boot partition */
-        BOOTLOADER_CAP_LEGACY = 1 << 3, /**<Bootloader supports legacy boot */
-        BOOTLOADER_CAP_EXTFS = 1 << 4,  /**<Bootloader supports ext2/3/4 */
-        BOOTLOADER_CAP_FATFS = 1 << 5,  /**<Bootloader supports vfat */
-        BOOTLOADER_CAP_MAX = 1 << 6
+        BOOTLOADER_CAP_UEFI = 1 << 1,    /**<Bootloader supports UEFI */
+        BOOTLOADER_CAP_GPT = 1 << 2,     /**<Bootloader supports GPT boot partition */
+        BOOTLOADER_CAP_LEGACY = 1 << 3,  /**<Bootloader supports legacy boot */
+        BOOTLOADER_CAP_EXTFS = 1 << 4,   /**<Bootloader supports ext2/3/4 */
+        BOOTLOADER_CAP_FATFS = 1 << 5,   /**<Bootloader supports vfat */
+        BOOTLOADER_CAP_PARTLESS = 1<< 6, /**<Bootloader supports partitionless boot */
+        BOOTLOADER_CAP_MAX = 1 << 7
 } BootLoaderCapability;
 
 /**

--- a/src/bootloaders/extlinux.c
+++ b/src/bootloaders/extlinux.c
@@ -86,7 +86,8 @@ static int extlinux_get_capabilities(const BootManager *manager)
                 return 0;
         }
 
-        return BOOTLOADER_CAP_GPT | BOOTLOADER_CAP_LEGACY | BOOTLOADER_CAP_EXTFS;
+        return BOOTLOADER_CAP_GPT | BOOTLOADER_CAP_LEGACY | BOOTLOADER_CAP_EXTFS |
+               BOOTLOADER_CAP_PARTLESS;
 }
 
 __cbm_export__ const BootLoader extlinux_bootloader = {.name = "extlinux",

--- a/src/bootloaders/grub2.c
+++ b/src/bootloaders/grub2.c
@@ -564,7 +564,7 @@ int grub2_get_capabilities(const BootManager *manager)
                 return 0;
         }
         /* Or in other words, we're the last bootloader candidate. */
-        return BOOTLOADER_CAP_LEGACY | BOOTLOADER_CAP_EXTFS;
+        return BOOTLOADER_CAP_LEGACY | BOOTLOADER_CAP_EXTFS | BOOTLOADER_CAP_PARTLESS;
 }
 
 __cbm_export__ const BootLoader grub2_bootloader = {.name = "grub2",

--- a/src/bootloaders/syslinux.c
+++ b/src/bootloaders/syslinux.c
@@ -88,7 +88,8 @@ static int syslinux_get_capabilities(const BootManager *manager)
                 return 0;
         }
 
-        return BOOTLOADER_CAP_GPT | BOOTLOADER_CAP_LEGACY | BOOTLOADER_CAP_FATFS;
+        return BOOTLOADER_CAP_GPT | BOOTLOADER_CAP_LEGACY | BOOTLOADER_CAP_FATFS |
+               BOOTLOADER_CAP_PARTLESS;
 }
 
 __cbm_export__ const BootLoader syslinux_bootloader = {.name = "syslinux",

--- a/src/bootman/bootman_private.h
+++ b/src/bootman/bootman_private.h
@@ -82,6 +82,15 @@ int kernel_compare_reverse(const void *a, const void *b);
  */
 const char *cbm_get_fstype_name(const char *boot_device);
 
+/**
+ * Check if the system supports a "partitionless" (the system has no /boot partition) boot.
+ * Conditions are:
+ * - The bootloader supports this.
+ * - The system is not UEFI.
+ * - The /boot folder is not empty.
+ */
+bool check_partitionless_boot(const BootManager *self, const char *boot_dir);
+
 /*
  * Editor modelines  -  https://www.wireshark.org/tools/modelines.html
  *


### PR DESCRIPTION
#174 restored support for partitionless /boot. However, this
introduced issues when (for whatever reason) there is content in
the /boot directory (instead of being empty) (see #175).

As partitionless boot is not an option for every bootloader, add a flag
indication bootloader support. Bootloaders without partitionless support
(and those on UEFI) will never try to use a partitionless /boot.