### PR TITLE
Make sure microcode initrd is loaded first

### DIFF
--- a/man/clr-boot-manager.1.in
+++ b/man/clr-boot-manager.1.in
@@ -159,6 +159,12 @@ Additional initrd arguments will be added to the kernel argument list, if desire
 the user may mask out system installed initrd files by creating symbolic links
 within \fB@KERNEL_CONF_DIRECTORY@/initrd.d\fR pointing to \fB/dev/null\fR with same
 name of system installed files.
+
+To support early microcode updates, clr-boot-manager will identify the first file it
+finds named *-ucode.cpio, and ensure that is the first initrd loaded by the boot
+manager. There is currently no deterministic sorting, however, a matching file in
+\fB@KERNEL_CONF_DIRECTORY@/initrd.d\fR will take precedence over the system-provided
+microcode initrd in \fB/usr/lib/initrd.d\fR.
 .RE
 
 .SH "ENVIRONMENT"

--- a/man/clr-boot-manager.1.in
+++ b/man/clr-boot-manager.1.in
@@ -152,19 +152,19 @@ tool non interactively. Possible values are: \fBno\fR, \fBfalse\fR\&.
 .RE
 
 .PP
-\fB@KERNEL_CONF_DIRECTORY@/initrd.d/*\fR
+\fB@USER_INITRD_DIRECTORY@/*\fR
 .RS 4
 A set of files that will be used as additional user's freestanding initrd files.
 Additional initrd arguments will be added to the kernel argument list, if desired
 the user may mask out system installed initrd files by creating symbolic links
-within \fB@KERNEL_CONF_DIRECTORY@/initrd.d\fR pointing to \fB/dev/null\fR with same
+within \fB@USER_INITRD_DIRECTORY@\fR pointing to \fB/dev/null\fR with same
 name of system installed files.
 
 To support early microcode updates, clr-boot-manager will identify the first file it
 finds named *-ucode.cpio, and ensure that is the first initrd loaded by the boot
 manager. There is currently no deterministic sorting, however, a matching file in
-\fB@KERNEL_CONF_DIRECTORY@/initrd.d\fR will take precedence over the system-provided
-microcode initrd in \fB/usr/lib/initrd.d\fR.
+\fB@USER_INITRD_DIRECTORY@\fR will take precedence over the system-provided
+microcode initrd in \fB@INITRD_DIRECTORY@\fR.
 .RE
 
 .SH "ENVIRONMENT"

--- a/man/meson.build
+++ b/man/meson.build
@@ -5,6 +5,8 @@ man_data = configuration_data()
 man_data.set('KERNEL_CONF_DIRECTORY', with_kernel_conf_dir)
 man_data.set('KERNEL_DIRECTORY', with_kernel_dir)
 man_data.set('VENDOR_KERNEL_CONF_DIRECTORY', with_kernel_vendor_conf_dir)
+man_data.set('INITRD_DIRECTORY', with_initrd_dir)
+man_data.set('USER_INITRD_DIRECTORY', with_user_initrd_dir)
 man_1 = configure_file(input : 'clr-boot-manager.1.in',
                        output : 'clr-boot-manager.1',
                        configuration : man_data,

--- a/src/bootloaders/systemd-class.c
+++ b/src/bootloaders/systemd-class.c
@@ -263,7 +263,7 @@ bool sd_class_install_kernel(const BootManager *manager, const Kernel *kernel)
 
         boot_manager_initrd_iterator_init(manager, &iter);
         while (boot_manager_initrd_iterator_next(&iter, &initrd_name)) {
-                if (ucode_initrd && 0 == strcmp(initrd_name, ucode_initrd)) {
+                if (streq(initrd_name, ucode_initrd)) {
                         /* This is the ucode early update initrd we already
                          * wrote above */
                         continue;

--- a/src/bootloaders/systemd-class.c
+++ b/src/bootloaders/systemd-class.c
@@ -263,7 +263,7 @@ bool sd_class_install_kernel(const BootManager *manager, const Kernel *kernel)
 
         boot_manager_initrd_iterator_init(manager, &iter);
         while (boot_manager_initrd_iterator_next(&iter, &initrd_name)) {
-                if (0 == strcmp(initrd_name, ucode_initrd)) {
+                if (ucode_initrd && 0 == strcmp(initrd_name, ucode_initrd)) {
                         /* This is the ucode early update initrd we already
                          * wrote above */
                         continue;

--- a/src/bootloaders/systemd-class.c
+++ b/src/bootloaders/systemd-class.c
@@ -243,6 +243,16 @@ bool sd_class_install_kernel(const BootManager *manager, const Kernel *kernel)
                                  get_kernel_destination_impl(manager),
                                  kernel->target.path);
 
+        /* Early microcode loading initrd must be the first entry */
+        initrd_name = boot_manager_get_ucode_initrd(manager);
+        if (initrd_name) {
+                cbm_writer_append_printf(writer,
+                                         "initrd %s/%s\n",
+                                         get_kernel_destination_impl(manager),
+                                         initrd_name);
+                boot_manager_remove_initrd(manager, initrd_name);
+        }
+
         /* Optional initrd */
         if (kernel->target.initrd_path) {
                 cbm_writer_append_printf(writer,

--- a/src/bootman/bootman.c
+++ b/src/bootman/bootman.c
@@ -843,7 +843,7 @@ static bool _boot_manager_enumerate_initrds_freestanding(BootManager *self, cons
                 entry->dir = strdup(dir);
 
                 /* Check whether this is a microcode cpio (*-ucode.cpio) */
-                if (found = strstr(initrd_name_val, ucode_needle)) {
+                if ((found = strstr(initrd_name_val, ucode_needle))) {
                         if ((strlen(initrd_name_val) - (size_t) (found - initrd_name_val)) == strlen(ucode_needle)) {
                                 if (!self->ucode_initrd) {
                                         LOG_INFO("Microcode initrd %s (%s) selected for early load",

--- a/src/bootman/bootman.c
+++ b/src/bootman/bootman.c
@@ -776,7 +776,6 @@ static bool _boot_manager_enumerate_initrds_freestanding(BootManager *self, cons
                 autofree(char) *path = NULL;
                 struct InitrdEntry *entry = NULL;
                 char *ucode_needle = "-ucode.cpio";
-                char *found = NULL;
 
                 path = string_printf("%s/%s", dir, ent->d_name);
 
@@ -843,10 +842,12 @@ static bool _boot_manager_enumerate_initrds_freestanding(BootManager *self, cons
                 entry->dir = strdup(dir);
 
                 /* Check whether this is a microcode cpio (*-ucode.cpio) */
-                found = strstr(initrd_name_val, ucode_needle);
-                if (found) {
+                size_t nlen = strlen(ucode_needle);
+                size_t hlen = strlen(initrd_name_val);
+                if (hlen > nlen) {
                         /* Ensure the match is at the end of the string */
-                        if ((strlen(initrd_name_val) - (size_t) (found - initrd_name_val)) == strlen(ucode_needle)) {
+                        const char *ext = &initrd_name_val[hlen-nlen];
+                        if (streq(ext, ucode_needle)) {
                                 if (!self->ucode_initrd) {
                                         LOG_INFO("Microcode initrd %s (%s) selected for early load",
                                                         path, initrd_name_key);

--- a/src/bootman/bootman.c
+++ b/src/bootman/bootman.c
@@ -843,7 +843,9 @@ static bool _boot_manager_enumerate_initrds_freestanding(BootManager *self, cons
                 entry->dir = strdup(dir);
 
                 /* Check whether this is a microcode cpio (*-ucode.cpio) */
-                if ((found = strstr(initrd_name_val, ucode_needle))) {
+                found = strstr(initrd_name_val, ucode_needle);
+                if (found) {
+                        /* Ensure the match is at the end of the string */
                         if ((strlen(initrd_name_val) - (size_t) (found - initrd_name_val)) == strlen(ucode_needle)) {
                                 if (!self->ucode_initrd) {
                                         LOG_INFO("Microcode initrd %s (%s) selected for early load",

--- a/src/bootman/bootman.c
+++ b/src/bootman/bootman.c
@@ -986,6 +986,16 @@ bool boot_manager_remove_initrd_freestanding(BootManager * self)
         return true;
 }
 
+char *boot_manager_get_ucode_initrd(const BootManager *manager)
+{
+        return manager->ucode_initrd;
+}
+
+bool boot_manager_remove_initrd(const BootManager *manager, const char *name)
+{
+        return nc_hashmap_remove(manager->initrd_freestanding, name);
+}
+
 void boot_manager_initrd_iterator_init(const BootManager *manager, NcHashmapIter *iter)
 {
         if (!iter) {

--- a/src/bootman/bootman.c
+++ b/src/bootman/bootman.c
@@ -993,11 +993,6 @@ char *boot_manager_get_ucode_initrd(const BootManager *manager)
         return manager->ucode_initrd;
 }
 
-bool boot_manager_remove_initrd(const BootManager *manager, const char *name)
-{
-        return nc_hashmap_remove(manager->initrd_freestanding, name);
-}
-
 void boot_manager_initrd_iterator_init(const BootManager *manager, NcHashmapIter *iter)
 {
         if (!iter) {

--- a/src/bootman/bootman.h
+++ b/src/bootman/bootman.h
@@ -432,6 +432,16 @@ bool boot_manager_copy_initrd_freestanding(BootManager *self);
  */
 bool boot_manager_remove_initrd_freestanding(BootManager * self);
 
+/**
+ * Get microcode initrd name
+ */
+char *boot_manager_get_ucode_initrd(const BootManager *manager);
+
+/**
+ * Remove an initrd from the boot manager hash
+ */
+bool boot_manager_remove_initrd(const BootManager *manager, const char *name);
+
 /*
  * Iterate initrd elements
  */

--- a/src/bootman/bootman.h
+++ b/src/bootman/bootman.h
@@ -437,11 +437,6 @@ bool boot_manager_remove_initrd_freestanding(BootManager * self);
  */
 char *boot_manager_get_ucode_initrd(const BootManager *manager);
 
-/**
- * Remove an initrd from the boot manager hash
- */
-bool boot_manager_remove_initrd(const BootManager *manager, const char *name);
-
 /*
  * Iterate initrd elements
  */

--- a/src/bootman/bootman_private.h
+++ b/src/bootman/bootman_private.h
@@ -38,6 +38,7 @@ struct BootManager {
         char *initrd_freestanding_dir; /**<Initrd without kernel deps directory */
         char *user_initrd_freestanding_dir; /**<User's initrd without kernel deps directory */
         NcHashmap *initrd_freestanding;/**<Array of initrds without kernel deps */
+        char *ucode_initrd;            /**<initrd containing microcode for early loading */
         void *data; /**<Bootloaders private data */
 };
 

--- a/tests/check-uefi.c
+++ b/tests/check-uefi.c
@@ -535,6 +535,91 @@ START_TEST(bootman_uefi_initrd_freestandings_ucode)
 }
 END_TEST
 
+START_TEST(bootman_uefi_initrd_freestandings_ucode_user)
+{
+        autofree(BootManager) *m = NULL;
+        autofree(char) *path_initrd = NULL;
+        autofree(char) *ucode_initrd = NULL;
+        autofree(char) *user_ucode_initrd = NULL;
+        char *initrd_name = "00-initrd";
+        char *ucode_initrd_name = "00-ucode.cpio";
+        char *user_ucode_initrd_name = "my-ucode.cpio";
+
+        m = prepare_playground(&uefi_config);
+        fail_if(!m, "Failed to prepare update playground");
+
+        path_initrd = string_printf("%s%s/%s",
+                                        PLAYGROUND_ROOT,
+                                        INITRD_DIRECTORY,
+                                        initrd_name);
+
+        ucode_initrd = string_printf("%s%s/%s",
+                                        PLAYGROUND_ROOT,
+                                        INITRD_DIRECTORY,
+                                        ucode_initrd_name);
+
+        user_ucode_initrd = string_printf("%s%s/%s",
+                                        PLAYGROUND_ROOT,
+                                        USER_INITRD_DIRECTORY,
+                                        user_ucode_initrd_name);
+
+        /* Have to create this directory ourselves; file_set_text() won't do it */
+        fail_if(!nc_mkdir_p(PLAYGROUND_ROOT "/" USER_INITRD_DIRECTORY, 00755), "Failed to create user initrd dir");
+
+        file_set_text(path_initrd, "Placeholder initrd");
+        file_set_text(ucode_initrd, "Placeholder ucode initrd");
+        file_set_text(user_ucode_initrd, "Placeholder user ucode initrd");
+        /* Validate image install */
+        boot_manager_set_image_mode(m, true);
+        fail_if(!boot_manager_enumerate_initrds_freestanding(m), "Failed to find freestanding initrd");
+
+        fail_if(!check_freestanding_initrds_available(m, initrd_name), "Failed reading from initrd path");
+        fail_if(!boot_manager_update(m), "Failed to update image");
+        fail_if(!check_initrd_file_exist(m, initrd_name), "Failed copying initrd file");
+        fail_if(!check_initrd_file_exist(m, ucode_initrd_name), "Failed copying ucode initrd file");
+        fail_if(!check_initrd_file_exist(m, user_ucode_initrd_name), "Failed copying user ucode initrd file");
+
+        /*
+         * Check whether the microcode (ucode) initrd is first in the list in
+         * the loader config files
+         */
+        for (int k = 0; k < uefi_config.n_kernels; k++) {
+                autofree(char) *conf_file = NULL;
+                autofree(char) *conf_path = NULL;
+                autofree(char) *config = NULL;
+                conf_file = string_printf("Clear-linux-%s-%s-%d.conf",
+                                uefi_config.initial_kernels[k].ktype,
+                                uefi_config.initial_kernels[k].version,
+                                uefi_config.initial_kernels[k].release);
+                conf_path = string_printf("%s/%s",
+                                BOOT_FULL "/loader/entries",
+                                conf_file);
+
+                if (file_get_text(conf_path, &config)) {
+                        autofree(char) *key = NULL;
+                        autofree(char) *exp = NULL;
+                        char *found = NULL;
+
+                        key = string_printf("initrd");
+
+                        found = strstr(config, key);
+                        fail_if(!found, "No initrd definitions found in %s:\n%s", conf_file, config);
+
+                        exp = string_printf("%s /efi/%s/freestanding-%s\n",
+                                        key, KERNEL_NAMESPACE, user_ucode_initrd_name);
+
+                        /*
+                         * We only want to compare this entry, not the rest of
+                         * the config
+                         */
+                        fail_if(0 != strncmp(found, exp, strlen(exp)),
+                                        "First initrd entry in config %s was not user's microcode (%s):\n%s",
+                                        conf_file, user_ucode_initrd_name, config);
+                }
+        }
+}
+END_TEST
+
 
 /**
  * Ensure all blobs are removed for garbage collected kernels
@@ -684,6 +769,7 @@ static Suite *core_suite(void)
         tcase_add_test(tc, bootman_uefi_set_kernel);
         tcase_add_test(tc, bootman_uefi_set_kernel_missing);
         tcase_add_test(tc, bootman_uefi_initrd_freestandings_ucode);
+        tcase_add_test(tc, bootman_uefi_initrd_freestandings_ucode_user);
         suite_add_tcase(s, tc);
 
         /* Tests without kernel modules */


### PR DESCRIPTION
Microcode early loading only works on the first initrd passed to the kernel, so make sure the first one we specify in the bootloader config is actually a microcode initrd.