### PR TITLE
Add remove-kernel command

### DIFF
--- a/data/completions/bash/clr-boot-manager.in
+++ b/data/completions/bash/clr-boot-manager.in
@@ -23,14 +23,14 @@ _clr_boot_manager() {
 
   case "$3" in
 		"$1"|help)
-			opts="version report-booted help update set-timeout get-timeout set-kernel list-kernels help"
+			opts="version report-booted help update set-timeout get-timeout set-kernel remove-kernel list-kernels help"
       COMPREPLY=($(compgen -W "${opts}" -- "${2}"))
 			;;
     get-timeout|list-kernels|update|set-timeout)
       opts="--path --image --no-efi-update"
       COMPREPLY=($(compgen -W "${opts}" -- "${2}"))
       ;;
-    set-kernel)
+    set-kernel|remove-kernel)
       opts="--path --image --no-efi-update"
       COMPREPLY=($(compgen -W "${opts}" -- "${2}"))
       COMPREPLY+=($(compgen -G "@KERNEL_DIRECTORY@/@KERNEL_NAMESPACE@*" ))

--- a/data/completions/zsh/_clr-boot-manager.in
+++ b/data/completions/zsh/_clr-boot-manager.in
@@ -26,6 +26,7 @@ local -a subcmds; subcmds=(
   "set-timeout:Set the timeout to be used by the bootloader"
   "get-timeout:Get the timeout to be used by the bootloader"
   "set-kernel:Configure kernel to be used at next boot"
+  "remove-kernel:Remove kernel from system"
   "list-kernels:Display currently selectable kernels to boot"
   "help:Display help information on available commands"
 )
@@ -50,7 +51,7 @@ if [[ -n "$state" ]]; then
         get-timeout|list-kernels|update)
           _arguments $args && ret=0
         ;;
-        set-kernel)
+        set-kernel|remove-kernel)
           local -a kernelpath
 
           kernelpath=(${opt_args[--path=]:-${opt_args[-p]}})

--- a/man/clr-boot-manager.1.in
+++ b/man/clr-boot-manager.1.in
@@ -112,6 +112,15 @@ Configure the default booting kernel.
 This command will not prevent the update command from changing the default kernel\&.
 .RE
 
+.PP
+\fBremove-kernel\fR
+.RS 4
+Remove a kernel from the system (both /boot and /usr locations).
+
+Warning: This can remove the only kernel from the system, ensure you have a default kernel
+set after running this command\&.
+.RE
+
 .SH "EXIT STATUS"
 .PP
 On success, 0 is returned, a non\-zero failure code otherwise\&

--- a/src/bootman/bootman.h
+++ b/src/bootman/bootman.h
@@ -268,6 +268,16 @@ void *boot_manager_get_data(BootManager *manager);
 void boot_manager_set_data(BootManager *manager, void *data);
 
 /**
+ * Wrapping function to remove a kernel that handles sanity checks and /boot mount state
+ *
+ * @param kernel A valid kernel instance
+ *
+ * @return a boolean value, indicating success or failure
+ */
+
+bool boot_manager_remove_kernel_wrapper(BootManager *manager, const Kernel *kernel);
+
+/**
  * Attempt to uninstall a previously installed kernel
  *
  * @param kernel A valid kernel instance

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -31,6 +31,7 @@ static SubCommand cmd_get_timeout;
 static SubCommand cmd_report_booted;
 static SubCommand cmd_list_kernels;
 static SubCommand cmd_set_kernel;
+static SubCommand cmd_remove_kernel;
 static char *binary_name = NULL;
 static NcHashmap *g_commands = NULL;
 static bool explicit_help = false;
@@ -205,6 +206,21 @@ kernel for the next time the system boots.",
         };
 
         if (!nc_hashmap_put(commands, cmd_set_kernel.name, &cmd_set_kernel)) {
+                DECLARE_OOM();
+                return EXIT_FAILURE;
+        }
+
+        /* Remove kernel */
+        cmd_remove_kernel = (SubCommand){
+                .name = "remove-kernel",
+                .blurb = "Remove the kernel from the system",
+                .help = "This command will remove a kernel from the system.",
+                .callback = cbm_command_remove_kernel,
+                .usage = " [--path=/path/to/filesystem/root]",
+                .requires_root = true
+        };
+
+        if (!nc_hashmap_put(commands, cmd_remove_kernel.name, &cmd_remove_kernel)) {
                 DECLARE_OOM();
                 return EXIT_FAILURE;
         }

--- a/src/cli/ops/kernels.c
+++ b/src/cli/ops/kernels.c
@@ -158,6 +158,83 @@ bool cbm_command_set_kernel(int argc, char **argv)
         return true;
 }
 
+bool cbm_command_remove_kernel(int argc, char **argv)
+{
+        autofree(char) *root = NULL;
+        autofree(BootManager) *manager = NULL;
+        autofree(KernelArray) *kernels = NULL;
+        bool forced_image = false;
+        char type[32] = { 0 };
+        char version[16] = { 0 };
+        int release = 0;
+        Kernel kern = { 0 };
+        bool update_efi_vars = true;
+
+        if (!cli_default_args_init(&argc, &argv, &root, &forced_image, &update_efi_vars)) {
+                return false;
+        }
+
+        manager = boot_manager_new();
+        if (!manager) {
+                DECLARE_OOM();
+                return false;
+        }
+
+        boot_manager_set_update_efi_vars(manager, update_efi_vars);
+
+        if (root) {
+                autofree(char) *realp = NULL;
+
+                realp = realpath(root, NULL);
+                if (!realp) {
+                        LOG_FATAL("Path specified does not exist: %s", root);
+                        return false;
+                }
+                /* Anything not / is image mode */
+                if (!streq(realp, "/")) {
+                        boot_manager_set_image_mode(manager, true);
+                } else {
+                        boot_manager_set_image_mode(manager, forced_image);
+                }
+
+                /* CBM will check this again, we just needed to check for
+                 * image mode.. */
+                if (!boot_manager_set_prefix(manager, root)) {
+                        return false;
+                }
+        } else {
+                boot_manager_set_image_mode(manager, forced_image);
+                /* Default to "/", bail if it doesn't work. */
+                if (!boot_manager_set_prefix(manager, "/")) {
+                        return false;
+                }
+        }
+
+        if (argc != 1) {
+                fprintf(stderr,
+                        "remove-kernel takes a kernel ID of the form %s.TYPE.VERSION-RELEASE\n",
+                        KERNEL_NAMESPACE);
+                return false;
+        }
+
+        if (sscanf(argv[optind], KERNEL_NAMESPACE ".%31[^.].%15[^-]-%d", type, version, &release) != 3) {
+                fprintf(stderr,
+                        "remove-kernel takes a kernel ID of the form %s.TYPE.VERSION-RELEASE\n",
+                        KERNEL_NAMESPACE);
+                return false;
+        }
+
+        kern.meta.ktype = type;
+        kern.meta.version = version;
+        kern.meta.release = release;
+
+        /* Let CBM take care of the rest */
+        if (!boot_manager_remove_kernel_wrapper(manager, &kern)) {
+                return false;
+        }
+        return true;
+}
+
 /*
  * Editor modelines  -  https://www.wireshark.org/tools/modelines.html
  *

--- a/src/cli/ops/kernels.h
+++ b/src/cli/ops/kernels.h
@@ -15,6 +15,7 @@
 
 bool cbm_command_list_kernels(int argc, char **argv);
 bool cbm_command_set_kernel(int argc, char **argv);
+bool cbm_command_remove_kernel(int argc, char **argv);
 
 /*
  * Editor modelines  -  https://www.wireshark.org/tools/modelines.html


### PR DESCRIPTION
In some cases users will want to remove kernels from their systems outside an update workflow. This is fairly painful to do manually so add a command to handle the operation which removes both the /boot data and configuration files as well as the /usr data.

The default symlink for a kernel type will remain as this is something that the update mechanism should be in control of and figuring out what would be the fallback is out of cbm's scope.

Signed-off-by: William Douglas <william.douglas@intel.com>