### PR TITLE
Require root for `get-timeout`

### DIFF
--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -158,7 +158,7 @@ This integer value will be used when next configuring the bootloader, and is use
 to forcibly delay the system boot for a specified number of seconds.",
                 .callback = cbm_command_get_timeout,
                 .usage = " [--path=/path/to/filesystem/root]",
-                .requires_root = false,
+                .requires_root = true,
         };
 
         if (!nc_hashmap_put(commands, cmd_get_timeout.name, &cmd_get_timeout)) {


### PR DESCRIPTION
When running `get-timeout` without root, it will fail with an error ('failed to create a new libblkid probe'). Require root permissions for the `get-timeout` subcommand to clarify this.