### PR TITLE
Prevent segfault in boot_manager_set_default_kernel

### DIFF
--- a/src/bootman/bootman.c
+++ b/src/bootman/bootman.c
@@ -407,6 +407,8 @@ bool boot_manager_set_default_kernel(BootManager *self, const Kernel *kernel)
         CHECK_DBG_RET_VAL(!cbm_is_sysconfig_sane(self->sysconfig), false,
                           "Sysconfig is not sane");
 
+        CHECK_ERR_RET_VAL(!kernel, false, "No kernel specified, bailing");
+
         /* Grab the available kernels */
         kernels = boot_manager_get_kernels(self);
         CHECK_ERR_RET_VAL(!kernels || kernels->len == 0, false,


### PR DESCRIPTION
If boot_manager_set_default_kernel() is called with a NULL kernel target, explicitly return false.