### PR TITLE
Avoid segfault when user-specified initrd is a symlink to /dev/null

### DIFF
--- a/src/bootman/bootman.c
+++ b/src/bootman/bootman.c
@@ -886,7 +886,7 @@ static bool _boot_manager_enumerate_initrds_freestanding(BootManager *self, cons
 
                 /* Check whether this is a microcode cpio (*-ucode.cpio) */
                 size_t nlen = strlen(ucode_needle);
-                size_t hlen = strlen(initrd_name_val);
+                size_t hlen = initrd_name_val ? strlen(initrd_name_val) : 0;
                 if (hlen > nlen) {
                         /* Ensure the match is at the end of the string */
                         const char *ext = &initrd_name_val[hlen-nlen];


### PR DESCRIPTION
We check for a microcode update initrd, so we can early-load it, by comparing the resolved file names to the ending "-ucode.cpio". In the case that a user has explicitly masked an initrd by symlinking a name in /etc/kernel/initrd.d/ to /dev/null, we store NULL in the resolved filename pointer.

Before we do the actual comparison, we do a strlen to make sure the filename is longer than the desired match. For a NULL pointer, that results in a segfault, so for that case, explicitly code the length to 0 instead of calling strlen on it.

Signature:
```
[277506.631610] clr-boot-manage[2369580]: segfault at 0 ip 0000558974796218 sp 00007ffca90d9658 error 4 cpu 18 in libc-2.40.so[196218,558974628000+184000] likely on CPU 18 (core 8, socket 0)
[277506.631627] Code: 0f 84 5e fd ff ff 48 89 f8 0f bc c9 f3 a4 c3 0f 1f 00 89 f8 62 a1 fd 00 ef c0 25 ff 0f 00 00 3d e0 0f 00 00 0f 87 28 01 00 00 <62> f1 7d 20 74 07 c5 fb 93 c0 85 c0 74 1a 0f bc c0 c3 66 0f 1f 44
```
```
$ sudo CBM_DEBUG=1 clr-boot-manager update
[DEBUG] cbm (../src/cli/cli.c:L142): No such file: //etc/kernel/update_efi_vars
[INFO] cbm (../src/bootman/bootman.c:L788): Current running kernel: 6.10.12-1467.native
[INFO] cbm (../src/bootman/sysconfig.c:L179): Discovered UEFI ESP: /dev/disk/by-partuuid/cb7f514a-2dd7-445d-9dec-2d5d105c6eee
[INFO] cbm (../src/bootman/sysconfig.c:L256): Fully resolved boot device: /dev/sda1
[DEBUG] cbm (../src/bootman/bootman.c:L141): shim-systemd caps: 0x26, wanted: 0x26
[DEBUG] cbm (../src/bootman/bootman.c:L156): UEFI boot now selected (shim-systemd)
[DEBUG] cbm (../src/bootman/bootman.c:L829): Non regular file: ///etc/kernel/initrd.d/.., skipping.
Segmentation fault
```
```
(gdb) bt
#0  0x0000555555396218 in __strlen_evex () from /usr/lib64/libc.so.6
#1  0x000055555555b9cc in _boot_manager_enumerate_initrds_freestanding () at ../src/bootman/bootman.c:889
#2  0x000055555555d570 in boot_manager_enumerate_initrds_freestanding () at ../src/bootman/bootman.c:918
#3  0x000055555555b170 in cbm_command_update_do () at ../src/cli/ops/update.c:82
#4  0x000055555555b2ac in cbm_command_update () at ../src/cli/ops/update.c:44
#5  0x000055555555990b in main () at ../src/cli/main.c:296
```